### PR TITLE
ignore all comprehensive_test* results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ logs/
 /comprehensive_test_20250728_102305
 /comprehensive_test_20250728_115411
 /workflow_moondream_narrative_20250801_095758
+/comprehensive_test*


### PR DESCRIPTION
Updates .gitignore to ignore new comprehensive_test folders as they are generated