### PR TITLE
Code quality baseline: CLAUDE.md, .gitignore fixes, test failures, bare except cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,9 @@ env/
 ENV/
 .winenv/
 
+# Claude Code worktrees (temporary session working directories)
+.claude/worktrees/
+
 # IDE files
 .vscode/
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -70,11 +70,9 @@ test_config.json
 build/
 dist/
 *.egg-info/
-idt/
+idt/dist/
+idt/build/
 BuildAndRelease/WinBuilds/
-
-# Local development build counter (preserve across git pulls)
-build/BUILD_TRACKER.json
 
 # Local development build counter (preserve across git pulls)
 build/BUILD_TRACKER.json
@@ -152,7 +150,6 @@ test_onnx*.py
 test_directml*.py
 dist_macos/
 BuildAndRelease/WinBuilds/dist_all/
-/BuildAndRelease
 imagedescriber/build_log_debug.txt
 
 # Video frame extraction output (test artifacts from CI and local runs)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,156 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Image Description Toolkit (IDT) is an AI-powered batch image/video description tool with two standalone applications:
+- **`idt`** — CLI dispatcher (`idt/idt_cli.py`) routing to all sub-commands
+- **`ImageDescriber`** — wxPython batch processing GUI (`imagedescriber/imagedescriber_wx.py`) with integrated viewer, prompt editor, and configuration manager
+
+Supported AI providers: Ollama (local/cloud), OpenAI GPT-4o, Claude (Anthropic), HuggingFace Florence-2.
+
+## Commands
+
+### Testing
+```bash
+pytest pytest_tests/
+python run_unit_tests.py        # Python 3.13-compatible alternative
+pytest --cov=scripts pytest_tests/
+pytest -m unit pytest_tests/   # markers: slow, integration, unit, regression
+```
+
+### Building (Windows)
+```batch
+BuildAndRelease\WinBuilds\builditall_wx.bat   # both apps
+cd idt && build_idt.bat                        # CLI only
+cd imagedescriber && build_imagedescriber_wx.bat
+```
+
+### Building (macOS)
+```bash
+./BuildAndRelease/MacBuilds/builditall_macos.command   # both apps
+cd imagedescriber && ./build_imagedescriber_wx.sh
+```
+
+### Smoke Testing After Build
+```bash
+dist/idt.exe version          # Windows
+dist/idt.exe --debug-paths
+./dist/idt version            # macOS
+```
+
+### Syntax Validation
+```bash
+python -m py_compile <file>
+```
+
+## Architecture
+
+### Dual Execution Model
+All code must support both modes:
+- **Development**: `python scripts/workflow.py`
+- **Production**: PyInstaller frozen executables (`idt.exe workflow`)
+- **Detection**: `getattr(sys, 'frozen', False)`
+- **Paths**: Always use `config_loader.py` or `resource_manager.py`, never raw `Path()` or `open()` for config files
+
+### Core Workflow Pipeline (`scripts/workflow.py`, 2468 lines)
+Four sequential steps:
+1. Video extraction → `video_frame_extractor.py`
+2. HEIC conversion → `ConvertImage.py`
+3. AI description → `image_describer.py`
+4. HTML output → `descriptions_to_html.py`
+
+Output directories: `wf_YYYY-MM-DD_HHMMSS_{model}_{prompt}`
+
+### Configuration Resolution Order (`scripts/config_loader.py`)
+1. Explicit path from caller
+2. File environment variable (e.g., `IDT_IMAGE_DESCRIBER_CONFIG`)
+3. `IDT_CONFIG_DIR` env var + filename
+4. Frozen exe dir + `/scripts/<filename>` or `/<filename>`
+5. Current working directory → bundled script dir (fallback)
+
+### AI Model Registry (Single Source of Truth)
+All model lists live in `models/`:
+- `models/claude_models.py` — Claude versions (latest: claude-opus-4-6, claude-haiku-4-5-20251001)
+- `models/openai_models.py` — OpenAI models (latest: gpt-4o, gpt-4o-mini, o1)
+- `models/model_registry.py` — central metadata
+- `models/provider_configs.py` — dynamic UI capabilities (`supports_prompts()`, `supports_custom_prompts()`)
+
+Imported by CLI, GUI, and chat features. Never duplicate model lists elsewhere.
+
+### Key Shared Utilities
+- `scripts/list_results.py` — `find_workflow_directories()`, `count_descriptions()`, `format_timestamp()`, `parse_directory_name()`
+- `analysis/combine_workflow_descriptions.py` — `get_image_date_for_sorting()` (EXIF priority order)
+- `shared/wx_common.py` — wxPython helpers
+- `scripts/workflow.py` — `sanitize_name()` for filesystem-safe names
+
+## Critical Rules
+
+### PyInstaller Frozen Mode Imports
+`from scripts.X`, `from imagedescriber.X`, `from analysis.X` **always fail in frozen mode**. Use:
+```python
+# At module level — NOT inside functions
+try:
+    from config_loader import load_json_config   # frozen mode
+except ImportError:
+    from scripts.config_loader import load_json_config  # dev mode
+```
+
+### wx Silent Failures
+wxPython **swallows all exceptions** in event handlers. When a button/menu/handler silently does nothing, run in dev mode first:
+```bash
+cd imagedescriber && .winenv/Scripts/python imagedescriber_wx.py
+```
+Reproduce the action — the exception prints to stderr immediately. Do not investigate architecture before doing this.
+
+### Before Any Code Change
+1. `grep -r "name"` to find ALL usages before renaming/changing signatures
+2. Check all callers — incomplete refactors caused 23% of commits to be bug fixes
+3. Verify PyInstaller compatibility with try/except import pattern
+4. Functions >500 lines require extra scrutiny
+
+### After Core File Changes
+For changes to `scripts/workflow.py`, `scripts/image_describer.py`, `idt/idt_cli.py`, or any file in `.spec` `hiddenimports`:
+1. `python -m py_compile <file>`
+2. Build the exe
+3. Run with test data: `dist\idt.exe workflow testimages`
+4. Check `wf_*/logs/*.log` for errors
+5. Only then claim the fix is complete
+
+### When Something Regresses
+1. `git log v<tag>..HEAD --oneline -- <file>` to find the breaking commit
+2. Run in dev mode, reproduce, read the exception
+3. Only then look at architecture
+
+## Conventions
+
+### Virtual Environment
+Windows virtual env uses `.winenv` (dot prefix), not `winenv`:
+```batch
+call .winenv\Scripts\activate.bat   ✓
+call winenv\Scripts\activate.bat    ✗
+```
+
+### Date/Time Format
+`M/D/YYYY H:MMP` — no leading zeros, A/P suffix. Examples: `3/25/2025 7:35P`, `10/16/2025 8:03A`.
+
+EXIF priority: `DateTimeOriginal` > `DateTimeDigitized` > `DateTime` > file mtime.
+
+### Window Titles
+Always show stats: `"XX%, X of Y images described"`. Live mode adds `"(Live)"` suffix.
+
+### Accessibility (WCAG 2.2 AA)
+- Use `wx.ListBox` instead of `wx.ListCtrl` (single tab stop)
+- Set `name=` parameter in widget constructors for screen reader labels
+- `wx.ListBox` items: concatenate data into single strings (no multi-column)
+
+### Session Summaries
+Create `docs/worktracking/YYYY-MM-DD-session-summary.md` for non-trivial sessions. Include: files changed, decisions, test results, what was NOT tested.
+
+## Additional Reference
+- `.github/copilot-instructions.md` — full agent guidelines and protocols
+- `docs/worktracking/PRE_COMMIT_VERIFICATION_CHECKLIST.md` — pre-commit checklist
+- `docs/AI_ONBOARDING.md` — current development status and active issues
+- `BuildAndRelease/BUILD_SYSTEM_REFERENCE.md` — build troubleshooting
+- `docs/archive/AI_AGENT_REFERENCE.md` — CLI reference, image optimization math, provider limits

--- a/analysis/stats_analysis.py
+++ b/analysis/stats_analysis.py
@@ -379,7 +379,7 @@ def parse_workflow_log(log_path: Path) -> Dict:
             start_dt = datetime.strptime(conversion_start, '%Y-%m-%d %H:%M:%S')
             end_dt = datetime.strptime(conversion_end, '%Y-%m-%d %H:%M:%S')
             stats['conversion_duration'] = (end_dt - start_dt).total_seconds()
-        except:
+        except Exception:
             pass
     
     # Also check frame_extractor log for video/frame counts

--- a/imagedescriber/ai_providers.py
+++ b/imagedescriber/ai_providers.py
@@ -387,7 +387,7 @@ class OllamaProvider(AIProvider):
         try:
             response = requests.get(f"{self.base_url}/api/tags", timeout=5)
             return response.status_code == 200
-        except:
+        except Exception:
             return False
     
     def get_available_models(self) -> List[str]:
@@ -414,7 +414,7 @@ class OllamaProvider(AIProvider):
                 self._models_cache = local_models
                 self._models_cache_time = current_time
                 return local_models
-        except:
+        except Exception:
             pass
         return []
     
@@ -692,7 +692,7 @@ class OpenAIProvider(AIProvider):
             # Sort to match our preferred order
             vision_models.sort(key=lambda m: DEV_OPENAI_MODELS.index(m) if m in DEV_OPENAI_MODELS else 999)
             return vision_models if vision_models else DEV_OPENAI_MODELS.copy()
-        except:
+        except Exception:
             pass
         
         # Fallback to known vision models (in preference order)
@@ -881,9 +881,9 @@ class OpenAIProvider(AIProvider):
                 try:
                     response_text = e.response.text if hasattr(e.response, 'text') else str(e.response)
                     error_details['response_text'] = response_text
-                except:
+                except Exception:
                     pass
-            
+
             # Log to console with structured format for easy parsing
             print(f"[ERROR] OpenAI API failure - {timestamp}")
             print(f"  Image: {Path(image_path).name}")
@@ -1177,9 +1177,9 @@ class ClaudeProvider(AIProvider):
                 try:
                     response_text = e.response.text if hasattr(e.response, 'text') else str(e.response)
                     error_details['response_text'] = response_text
-                except:
+                except Exception:
                     pass
-            
+
             # Log to console with structured format for easy parsing
             print(f"[ERROR] Claude API failure - {timestamp}")
             print(f"  Image: {Path(image_path).name}")
@@ -1256,8 +1256,8 @@ class OllamaCloudProvider(AIProvider):
                     return True
             
             return False
-            
-        except:
+
+        except Exception:
             return False
     
     def get_available_models(self) -> List[str]:
@@ -1286,7 +1286,7 @@ class OllamaCloudProvider(AIProvider):
                 self._models_cache = cloud_models
                 self._models_cache_time = current_time
                 return cloud_models
-        except:
+        except Exception:
             pass
         return []
     

--- a/imagedescriber/chat_window_wx.py
+++ b/imagedescriber/chat_window_wx.py
@@ -447,7 +447,7 @@ class ChatWindow(wx.Dialog):
                 try:
                     dt = datetime.fromisoformat(timestamp)
                     time_str = dt.strftime("%I:%M %p")
-                except:
+                except Exception:
                     pass
             
             # Format message for ListBox display

--- a/imagedescriber/imagedescriber_wx.py
+++ b/imagedescriber/imagedescriber_wx.py
@@ -152,7 +152,7 @@ except ImportError as e:
         with open('chat_import_error.log', 'w') as f:
             f.write(f"CHAT IMPORT ERROR: {e}\n")
             f.write(traceback.format_exc())
-    except:
+    except Exception:
         pass
     print(f"CHAT IMPORT ERROR: {e}")
     print(traceback.format_exc())
@@ -6866,7 +6866,7 @@ if __name__ == "__main__":
             with open(crash_log_path, "w") as f:
                 f.write(error_msg)
             print(f"Error logged to {crash_log_path}")
-        except:
+        except Exception:
             print("Could not write crash log")
 
         # Show error dialog for GUI mode (don't use input() - breaks windowed executables)
@@ -6878,5 +6878,5 @@ if __name__ == "__main__":
                 "Critical Error",
                 wx.OK | wx.ICON_ERROR
             )
-        except:
+        except Exception:
             pass  # If wx fails too, just exit

--- a/imagedescriber/viewer_components.py
+++ b/imagedescriber/viewer_components.py
@@ -73,7 +73,7 @@ class WorkflowMonitor(threading.Thread):
                         self.last_modified = stat.st_mtime
                         # Notify window to refresh via thread-safe event
                         wx.PostEvent(self.callback_window, LiveUpdateEvent())
-            except:
+            except Exception:
                 pass
             
             time.sleep(2)  # Check every 2 seconds
@@ -513,7 +513,7 @@ class ViewerPanel(wx.Panel):
                     self.image_preview_bitmap = bitmap
                 else:
                     self.image_preview_bitmap = None
-            except:
+            except Exception:
                 self.image_preview_bitmap = None
             
             self.image_preview_panel.Refresh()
@@ -537,7 +537,7 @@ class ViewerPanel(wx.Panel):
             img = img.Scale(new_w, new_h, wx.IMAGE_QUALITY_HIGH)
             self.image_preview_bitmap = wx.Bitmap(img)
             self.image_preview_panel.Refresh()
-        except:
+        except Exception:
             # Silently create placeholder for any loading errors
             self.image_preview_bitmap = None
             self.image_preview_panel.Refresh()

--- a/imagedescriber/workers_wx.py
+++ b/imagedescriber/workers_wx.py
@@ -2213,7 +2213,7 @@ class SaveWorkspaceWorker(threading.Thread):
                     try:
                         if self.old_ws_dir.exists() and not any(self.old_ws_dir.iterdir()):
                             self.old_ws_dir.rmdir()
-                    except:
+                    except Exception:
                         pass  # Ignore cleanup errors
             
             # Save to file with proper JSON encoding

--- a/models/check_models.py
+++ b/models/check_models.py
@@ -180,7 +180,7 @@ def get_model_metadata(model_name: str) -> Dict:
                 models_info = config.get('available_models', {})
                 if model_name in models_info:
                     return models_info[model_name]
-        except:
+        except Exception:
             pass
     
     return {}

--- a/models/manage_models.py
+++ b/models/manage_models.py
@@ -306,7 +306,7 @@ def get_installed_ollama_models() -> List[str]:
         if response.status_code == 200:
             data = response.json()
             return [m['name'] for m in data.get('models', [])]
-    except:
+    except Exception:
         pass
     return []
 
@@ -317,7 +317,7 @@ def is_ollama_running() -> bool:
         import requests
         response = requests.get("http://localhost:11434/api/tags", timeout=2)
         return response.status_code == 200
-    except:
+    except Exception:
         return False
 
 

--- a/models/model_registry.py
+++ b/models/model_registry.py
@@ -127,7 +127,7 @@ class ModelRegistry:
                     data = response.json()
                     installed = [m['name'] for m in data.get('models', [])]
                     return model_name in installed
-            except:
+            except Exception:
                 pass
         
         # For other providers, assume available if configured

--- a/pytest_tests/unit/test_configuration_system.py
+++ b/pytest_tests/unit/test_configuration_system.py
@@ -142,16 +142,16 @@ class TestBasicConfigResolution:
         with tempfile.TemporaryDirectory() as tmpdir:
             tmp_path = Path(tmpdir)
             
-            config_file = tmp_path / "test_cwd_config.json"
+            config_file = tmp_path.resolve() / "test_cwd_config.json"
             config_file.write_text('{"test": "cwd"}')
-            
+
             original_cwd = Path.cwd()
             try:
                 os.chdir(tmp_path)
-                
+
                 path, source = resolve_config("test_cwd_config.json")
-                
-                assert path == config_file, "Should find config in cwd"
+
+                assert path.resolve() == config_file, "Should find config in cwd"
                 assert source == "cwd", "Source should be 'cwd'"
                 
             finally:

--- a/pytest_tests/unit/test_window_title_builder_inline.py
+++ b/pytest_tests/unit/test_window_title_builder_inline.py
@@ -172,9 +172,13 @@ def test_window_title_builder():
     print(f"\n{'=' * 50}")
     print(f"Results: {tests_passed} passed, {tests_failed} failed")
     print(f"{'=' * 50}")
-    
-    return tests_failed == 0
+
+    assert tests_failed == 0, f"{tests_failed} inline window title test(s) failed"
 
 if __name__ == "__main__":
-    success = test_window_title_builder()
-    sys.exit(0 if success else 1)
+    try:
+        test_window_title_builder()
+        sys.exit(0)
+    except AssertionError as e:
+        print(f"FAILED: {e}")
+        sys.exit(1)

--- a/scripts/image_describer.py
+++ b/scripts/image_describer.py
@@ -1940,7 +1940,7 @@ class ImageDescriber:
             minutes = float(coord_tuple[1])
             seconds = float(coord_tuple[2])
             return degrees + (minutes / 60.0) + (seconds / 3600.0)
-        except:
+        except Exception:
             return 0.0
     
     def format_metadata(self, metadata: Dict[str, Any]) -> str:
@@ -2172,7 +2172,7 @@ def get_available_prompt_styles(config_file: str = "image_describer_config.json"
             with open(config_path, 'r', encoding='utf-8') as f:
                 config = json.load(f)
             return list(config.get('prompt_variations', {}).keys())
-    except:
+    except Exception:
         pass
     
     # Default fallback

--- a/scripts/metadata_extractor.py
+++ b/scripts/metadata_extractor.py
@@ -22,10 +22,8 @@ except ImportError:
 try:
     from PIL import Image
     from PIL.ExifTags import TAGS, GPSTAGS
-except ImportError:
-    print("ERROR: PIL (Pillow) not installed")
-    print("Install with: pip install Pillow")
-    sys.exit(1)
+except ImportError as e:
+    raise ImportError("PIL (Pillow) is required. Install with: pip install Pillow") from e
 
 # Try to enable HEIC support
 HEIC_SUPPORT = False

--- a/scripts/versioning.py
+++ b/scripts/versioning.py
@@ -20,7 +20,7 @@ import json
 import os
 import sys
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -182,7 +182,7 @@ def log_build_banner(logger=None, stream=None) -> None:
     full = f"{base} {format_build(num)}"
     sha, dirty = get_git_info()
     mode = 'Frozen' if is_frozen() else 'Dev'
-    ts = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%SZ')
+    ts = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%SZ')
 
     lines = [
         "Image Description Toolkit",

--- a/scripts/video_describer.py
+++ b/scripts/video_describer.py
@@ -429,7 +429,7 @@ class VideoDescriber:
         try:
             if hasattr(provider, 'generate_text'):
                 return provider.generate_text(summary_prompt, model)
-        except:
+        except Exception:
             pass
         
         # Fallback: return combined descriptions
@@ -594,6 +594,9 @@ Examples:
     print(f"Failed: {describer.statistics['failed']}")
     total_time = describer.statistics['end_time'] - describer.statistics['start_time'] if describer.statistics['end_time'] else 0
     print(f"Total time: {total_time:.1f}s")
+
+    if describer.statistics['failed'] > 0:
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/scripts/video_frame_extractor.py
+++ b/scripts/video_frame_extractor.py
@@ -124,7 +124,7 @@ class VideoFrameExtractor:
                 from workflow_utils import WorkflowConfig
                 config = WorkflowConfig()
                 logs_dir = config.base_output_dir / "logs"
-            except:
+            except Exception:
                 # Fallback to relative path
                 logs_dir = Path("workflow_output") / "logs"
                 

--- a/scripts/web_image_downloader.py
+++ b/scripts/web_image_downloader.py
@@ -32,27 +32,12 @@ from io import BytesIO
 try:
     from bs4 import BeautifulSoup
 except ImportError as e:
-    print(f"ERROR: BeautifulSoup4 import failed: {e}")
-    print("Install with: pip install beautifulsoup4")
-    # Check if we're in a frozen executable
-    import sys
-    if getattr(sys, 'frozen', False):
-        print("Running in frozen mode - checking available modules...")
-        import os
-        meipass = getattr(sys, '_MEIPASS', '')
-        if meipass:
-            bs4_path = os.path.join(meipass, 'bs4')
-            print(f"bs4 path exists: {os.path.exists(bs4_path)}")
-            if os.path.exists(bs4_path):
-                print(f"bs4 directory contents: {os.listdir(bs4_path)[:10]}")
-    sys.exit(1)
+    raise ImportError("beautifulsoup4 is required. Install with: pip install beautifulsoup4") from e
 
 try:
     from PIL import Image
-except ImportError:
-    print("ERROR: Pillow not installed")
-    print("Install with: pip install Pillow")
-    sys.exit(1)
+except ImportError as e:
+    raise ImportError("Pillow is required. Install with: pip install Pillow") from e
 
 
 class WebImageDownloader:


### PR DESCRIPTION
## Summary

First pass as dev lead — establishes a clean baseline before the /ultrareview run.

- Add `CLAUDE.md` with build commands, architecture, and critical dev rules (distilled from `.github/copilot-instructions.md`)
- Fix 3 `.gitignore` bugs: `idt/` and `/BuildAndRelease` were listed as build artifacts, silently blocking new source files from being tracked; removed duplicate entry
- Add `.claude/worktrees/` to `.gitignore` so Claude Code session directories don't show up in GitHub Desktop

**Test failures fixed (2):**
- `test_cwd_resolution`: macOS `/var` → `/private/var` symlink mismatch between `tempfile` and `Path.cwd()`
- `test_main_missing_video_exits_nonzero`: `video_describer` was logging failures but exiting 0

**Module-level `sys.exit` removed (2 files):**
- `scripts/metadata_extractor.py` and `scripts/web_image_downloader.py` called `sys.exit(1)` on missing imports at module level, crashing pytest collection entirely and any process that imported them without full deps

**Other fixes:**
- `datetime.utcnow()` deprecation in `versioning.py` → `datetime.now(timezone.utc)`
- Bare `except:` → `except Exception:` across 24 instances in 10 files (catches `SystemExit`/`KeyboardInterrupt` unintentionally)
- `test_window_title_builder_inline.py` returned a bool instead of asserting — test never failed pytest on wrong results
- Bare `except:` in `video_describer._combine_descriptions` tightened

## Test plan
- [x] 311/311 unit tests passing, zero warnings
- [x] No bare `except:` remaining in codebase (`grep` verified)
- [x] No `sys.exit` at module level remaining in scripts

🤖 Generated with [Claude Code](https://claude.ai/claude-code)