### PR TITLE
chore: ignore MacBuilds/dist_all/ build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,6 +153,7 @@ test_onnx*.py
 test_directml*.py
 dist_macos/
 BuildAndRelease/WinBuilds/dist_all/
+BuildAndRelease/MacBuilds/dist_all/
 imagedescriber/build_log_debug.txt
 
 # Video frame extraction output (test artifacts from CI and local runs)


### PR DESCRIPTION
Mac equivalent of the already-ignored `BuildAndRelease/WinBuilds/dist_all/`. The staging directory was showing as ~8 untracked files in GitHub Desktop (LICENSE, README.md, idt binary, install script, Applications symlink).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)