### PR TITLE
feat: Copy Image and Copy Image + Description clipboard actions

### DIFF
--- a/docs/USER_GUIDE_COMPLETE.md
+++ b/docs/USER_GUIDE_COMPLETE.md
@@ -313,6 +313,14 @@ For more detail on web download behaviour and options, see `docs/WEB_DOWNLOAD_GU
 
 **All Descriptions dialog:** Browse every description across all images in the workspace in one place — use `Descriptions → Show All Descriptions...` to open it. Useful for comparing results across models and prompts.
 
+**Copying to the clipboard:** The Descriptions menu offers four clipboard options for the selected image:
+- **Copy Description** — copies the description text only
+- **Copy Image Path** — copies the full file path as text
+- **Copy Image** — copies the image itself as a bitmap (paste directly into Word, Keynote, Slack, etc.)
+- **Copy Image + Description** — copies both the image and the description text in a single clipboard operation; apps that understand only one format will receive whichever they request (e.g. a text editor gets the description, an image editor gets the bitmap)
+
+The **Copy Image** button in the viewer panel provides the same single-image copy without opening the menu. For video items, the first extracted frame is used.
+
 **Saving your workspace:** Press `Ctrl+S` to save a `.idw` workspace file. This persists all descriptions and processing state. Reopen the file later and pick up exactly where you left off. Workspace files are valuable for large batch jobs — save frequently.
 
 ---

--- a/docs/USER_GUIDE_V4.md
+++ b/docs/USER_GUIDE_V4.md
@@ -304,6 +304,8 @@ The **GUI ImageDescriber** (`imagedescriber.exe`) provides an intuitive, visual 
 - **Delete Description** - Remove a description (keep at least one)
 - **Copy Description** - Copy the selected description to clipboard
 - **Copy Image Path** - Copy the full file path to clipboard
+- **Copy Image** - Copy the image itself to clipboard as a bitmap (paste into Word, Keynote, Slack, etc.)
+- **Copy Image + Description** - Copy both the image and the description in one operation; apps that understand only one format receive whichever they request
 - **Show All Descriptions** - View all descriptions for the selected image in one dialog
 
 **View Menu:**

--- a/imagedescriber/imagedescriber_wx.py
+++ b/imagedescriber/imagedescriber_wx.py
@@ -1539,6 +1539,12 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
         copy_path_item = desc_menu.Append(wx.ID_ANY, "Copy Image &Path")
         self.Bind(wx.EVT_MENU, self.on_copy_image_path, copy_path_item)
 
+        copy_image_item = desc_menu.Append(wx.ID_ANY, "Copy &Image")
+        self.Bind(wx.EVT_MENU, self.on_copy_image, copy_image_item)
+
+        copy_image_desc_item = desc_menu.Append(wx.ID_ANY, "Copy Image + &Description")
+        self.Bind(wx.EVT_MENU, self.on_copy_image_and_description, copy_image_desc_item)
+
         desc_menu.AppendSeparator()
 
         show_all_item = desc_menu.Append(wx.ID_ANY, "&Show All Descriptions...")
@@ -6099,6 +6105,67 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
             wx.TheClipboard.SetData(wx.TextDataObject(self.current_image_item.file_path))
             wx.TheClipboard.Close()
             self.SetStatusText("Image path copied to clipboard", 0)
+
+    def _get_copyable_image_path(self):
+        """Return the resolved display path for the current image (handles videos and HEIC).
+
+        For video items, returns the first extracted frame path.
+        For regular images, returns the file_path resolved through the workspace.
+        Returns None if no image is selected or path cannot be resolved.
+        """
+        if not self.current_image_item:
+            return None
+        if self.current_image_item.item_type == "video":
+            frame_path = self._get_video_preview_frame(self.current_image_item)
+            if not frame_path:
+                return None
+            resolved = self.resolve_image_path(frame_path)
+        else:
+            resolved = self.resolve_image_path(self.current_image_item.file_path)
+        from pathlib import Path as _Path
+        resolved = _Path(str(resolved))
+        return resolved if resolved.exists() else None
+
+    def on_copy_image(self, event):
+        """Copy current image to clipboard as a bitmap"""
+        path = self._get_copyable_image_path()
+        if not path:
+            show_warning(self, "No image available to copy")
+            return
+        bmp = wx.Bitmap(str(path), wx.BITMAP_TYPE_ANY)
+        if not bmp.IsOk():
+            show_warning(self, "Could not load image for clipboard")
+            return
+        if wx.TheClipboard.Open():
+            wx.TheClipboard.SetData(wx.BitmapDataObject(bmp))
+            wx.TheClipboard.Close()
+            self.SetStatusText("Image copied to clipboard", 0)
+
+    def on_copy_image_and_description(self, event):
+        """Copy both the current image and its description to the clipboard.
+
+        Uses wx.DataObjectComposite so apps that understand only one format
+        (e.g. a plain text editor) receive whichever they request.
+        """
+        path = self._get_copyable_image_path()
+        if not path:
+            show_warning(self, "No image available to copy")
+            return
+        if not self.current_image_item or not self.current_image_item.descriptions:
+            show_warning(self, "No description to copy")
+            return
+        bmp = wx.Bitmap(str(path), wx.BITMAP_TYPE_ANY)
+        if not bmp.IsOk():
+            show_warning(self, "Could not load image for clipboard")
+            return
+        desc = self.current_image_item.descriptions[-1].text
+        composite = wx.DataObjectComposite()
+        composite.Add(wx.BitmapDataObject(bmp))
+        composite.Add(wx.TextDataObject(desc))
+        if wx.TheClipboard.Open():
+            wx.TheClipboard.SetData(composite)
+            wx.TheClipboard.Close()
+            self.SetStatusText("Image and description copied to clipboard", 0)
 
     def on_show_all_descriptions(self, event):
         """Show all descriptions across all images"""

--- a/imagedescriber/viewer_components.py
+++ b/imagedescriber/viewer_components.py
@@ -270,6 +270,10 @@ class ViewerPanel(wx.Panel):
         self.copy_btn = wx.Button(right_panel, label="Copy Text")
         self.copy_btn.Bind(wx.EVT_BUTTON, self.on_copy_text)
         btn_sizer.Add(self.copy_btn, 0, wx.ALL, 5)
+
+        self.copy_image_btn = wx.Button(right_panel, label="Copy Image")
+        self.copy_image_btn.Bind(wx.EVT_BUTTON, self.on_copy_image)
+        btn_sizer.Add(self.copy_image_btn, 0, wx.ALL, 5)
         
         right_sizer.Add(btn_sizer, 0, wx.EXPAND | wx.ALL, 5)
         
@@ -616,7 +620,28 @@ class ViewerPanel(wx.Panel):
             if wx.TheClipboard.Open():
                 wx.TheClipboard.SetData(wx.TextDataObject(text))
                 wx.TheClipboard.Close()
-    
+
+    def _get_current_image_path(self):
+        """Return resolved Path for the currently selected entry's image, or None."""
+        sel = self.desc_list.GetSelection()
+        if sel == wx.NOT_FOUND or sel >= len(self.entries):
+            return None
+        file_path = self.entries[sel].get('file_path', '')
+        if not file_path:
+            return None
+        resolved = self.resolve_image_path(file_path)
+        return resolved if resolved.exists() else None
+
+    def on_copy_image(self, event):
+        """Copy the currently selected image to the clipboard as a bitmap"""
+        path = self._get_current_image_path()
+        if not path:
+            return
+        bmp = wx.Bitmap(str(path), wx.BITMAP_TYPE_ANY)
+        if bmp.IsOk() and wx.TheClipboard.Open():
+            wx.TheClipboard.SetData(wx.BitmapDataObject(bmp))
+            wx.TheClipboard.Close()
+
     def get_workflow_progress(self):
         """Get workflow progress - same approach as image_describer.py.
         Returns (described_count, total_images) tuple.


### PR DESCRIPTION
## Summary

- Adds **Copy Image** to the Descriptions menu — puts the current image on the clipboard as a bitmap so users can paste directly into Word, Keynote, Slack, etc.
- Adds **Copy Image + Description** to the Descriptions menu — uses `wx.DataObjectComposite` so each receiving app gets the format it understands (image editors get the bitmap, text editors get the description text)
- Adds a **Copy Image** button to the viewer panel alongside the existing Copy Text button
- Video items use the first extracted frame; HEIC inputs use the already-converted path
- Updates `docs/USER_GUIDE_COMPLETE.md` (bundled in Windows installer and macOS DMG) and `docs/USER_GUIDE_V4.md` to document all four clipboard options

## Test plan

- [ ] Select an image with a description in ImageDescriber, use Descriptions → Copy Image, paste into another app (Photos, Word, Slack) — image appears
- [ ] Use Descriptions → Copy Image + Description, paste into a text editor — description text appears; paste into an image app — image appears
- [ ] Click the Copy Image button in the viewer panel — image pastes correctly
- [ ] Select a video item — Copy Image uses the first extracted frame without error
- [ ] Select an image with no description — Copy Image + Description shows a warning
- [ ] Select no image — Copy Image shows a warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)