### PR TITLE
fix: register pillow-heif opener so HEIC files copy to clipboard

### DIFF
--- a/imagedescriber/imagedescriber_wx.py
+++ b/imagedescriber/imagedescriber_wx.py
@@ -6133,6 +6133,11 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
         """
         try:
             from PIL import Image as PILImage
+            try:
+                import pillow_heif
+                pillow_heif.register_heif_opener()
+            except ImportError:
+                pass
             img = PILImage.open(str(path)).convert('RGB')
             w, h = img.size
             wx_image = wx.Image(w, h)

--- a/imagedescriber/viewer_components.py
+++ b/imagedescriber/viewer_components.py
@@ -639,6 +639,11 @@ class ViewerPanel(wx.Panel):
             return
         try:
             from PIL import Image as PILImage
+            try:
+                import pillow_heif
+                pillow_heif.register_heif_opener()
+            except ImportError:
+                pass
             img = PILImage.open(str(path)).convert('RGB')
             w, h = img.size
             wx_image = wx.Image(w, h)


### PR DESCRIPTION
## Summary

HEIC is the iPhone default format — any user opening a camera roll folder will have HEIC files. `_load_bitmap_for_clipboard` was calling PIL `Image.open()` without first registering the HEIF opener, so all HEIC files silently failed with "Could not load image."

Registers `pillow_heif.register_heif_opener()` before opening in both `imagedescriber_wx.py` and `viewer_components.py`, matching the existing pattern in `image_describer.py`. Degrades gracefully if `pillow-heif` is not installed (the opener is listed as a requirement but may not be present in all environments).

## Test plan

- [ ] Load a folder of iPhone HEIC photos
- [ ] Select one and use Descriptions → Copy Image — image pastes correctly
- [ ] Use Copy Image + Description — both formats available
- [ ] Copy Image button in viewer panel works on HEIC

🤖 Generated with [Claude Code](https://claude.com/claude-code)