### PR TITLE
fix: use pbcopy on macOS to avoid UTF-16 clipboard text corruption

### DIFF
--- a/imagedescriber/imagedescriber_wx.py
+++ b/imagedescriber/imagedescriber_wx.py
@@ -6090,9 +6090,7 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
             return
 
         desc = self.current_image_item.descriptions[-1].text
-        if wx.TheClipboard.Open():
-            wx.TheClipboard.SetData(wx.TextDataObject(desc))
-            wx.TheClipboard.Close()
+        if self._copy_text_to_clipboard(desc):
             self.SetStatusText("Description copied to clipboard", 0)
 
     def on_copy_image_path(self, event):
@@ -6101,10 +6099,37 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
             show_warning(self, "No image selected")
             return
 
-        if wx.TheClipboard.Open():
-            wx.TheClipboard.SetData(wx.TextDataObject(self.current_image_item.file_path))
-            wx.TheClipboard.Close()
+        if self._copy_text_to_clipboard(self.current_image_item.file_path):
             self.SetStatusText("Image path copied to clipboard", 0)
+
+    @staticmethod
+    def _copy_text_to_clipboard(text):
+        """Copy text to the clipboard with correct encoding on every platform.
+
+        wx.TextDataObject on macOS puts text as public.utf16-plain-text (raw
+        UTF-16 bytes). Native macOS apps like Messages expect NSPasteboardTypeString
+        and display the raw bytes as spaced-out characters. pbcopy writes
+        proper UTF-8 which macOS converts to NSPasteboardTypeString automatically.
+        On Windows, wx.TextDataObject works correctly and is used directly.
+
+        Returns True on success, False on failure.
+        """
+        import sys
+        if sys.platform == 'darwin':
+            try:
+                import subprocess
+                subprocess.run(['pbcopy'], input=text.encode('utf-8'), check=True)
+                return True
+            except Exception:
+                pass  # fall through to wx fallback
+        try:
+            if wx.TheClipboard.Open():
+                wx.TheClipboard.SetData(wx.TextDataObject(text))
+                wx.TheClipboard.Close()
+                return True
+        except Exception:
+            pass
+        return False
 
     def _get_copyable_image_path(self):
         """Return the resolved display path for the current image (handles videos and HEIC).
@@ -6179,9 +6204,17 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
             show_warning(self, "Could not load image for clipboard")
             return
         desc = self.current_image_item.descriptions[-1].text
+        import sys
         composite = wx.DataObjectComposite()
         composite.Add(wx.BitmapDataObject(bmp))
-        composite.Add(wx.TextDataObject(desc))
+        if sys.platform == 'darwin':
+            # wx.TextDataObject puts public.utf16-plain-text which macOS apps
+            # can misread as raw bytes. Use public.utf8-plain-text explicitly.
+            utf8_obj = wx.CustomDataObject(wx.DataFormat('public.utf8-plain-text'))
+            utf8_obj.SetData(desc.encode('utf-8'))
+            composite.Add(utf8_obj)
+        else:
+            composite.Add(wx.TextDataObject(desc))
         if wx.TheClipboard.Open():
             wx.TheClipboard.SetData(composite)
             wx.TheClipboard.Close()
@@ -6435,9 +6468,7 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
                 elif result == wx.ID_NO:
                     # Copy command to clipboard
                     install_cmd = "curl -fsSL https://ollama.ai/install.sh | sh"
-                    if wx.TheClipboard.Open():
-                        wx.TheClipboard.SetData(wx.TextDataObject(install_cmd))
-                        wx.TheClipboard.Close()
+                    if self._copy_text_to_clipboard(install_cmd):
                         from shared.wx_common import show_info
                         show_info(self, "Command Copied",
                                  f"Installation command copied to clipboard:\n\n{install_cmd}\n\n"
@@ -6480,9 +6511,7 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
                 elif result == wx.ID_NO:
                     # Copy command to clipboard
                     install_cmd = "winget install ollama"
-                    if wx.TheClipboard.Open():
-                        wx.TheClipboard.SetData(wx.TextDataObject(install_cmd))
-                        wx.TheClipboard.Close()
+                    if self._copy_text_to_clipboard(install_cmd):
                         from shared.wx_common import show_info
                         show_info(self, "Command Copied",
                                  f"Installation command copied to clipboard:\n\n{install_cmd}\n\n"
@@ -6547,9 +6576,7 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
 
                 if result == wx.ID_YES:
                     install_cmd = "brew install ffmpeg"
-                    if wx.TheClipboard.Open():
-                        wx.TheClipboard.SetData(wx.TextDataObject(install_cmd))
-                        wx.TheClipboard.Close()
+                    self._copy_text_to_clipboard(install_cmd)
                     show_info(self, "Command Copied",
                              f"Copied to clipboard:\n\n{install_cmd}\n\n"
                              "1. Open Terminal\n"
@@ -6580,9 +6607,7 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
 
                 if result == wx.ID_YES:
                     install_cmd = "winget install Gyan.FFmpeg"
-                    if wx.TheClipboard.Open():
-                        wx.TheClipboard.SetData(wx.TextDataObject(install_cmd))
-                        wx.TheClipboard.Close()
+                    self._copy_text_to_clipboard(install_cmd)
                     show_info(self, "Command Copied",
                              f"Copied to clipboard:\n\n{install_cmd}\n\n"
                              "1. Open Command Prompt or PowerShell\n"

--- a/imagedescriber/viewer_components.py
+++ b/imagedescriber/viewer_components.py
@@ -617,6 +617,14 @@ class ViewerPanel(wx.Panel):
         """Copy description to clipboard"""
         text = self.desc_text.GetValue()
         if text:
+            import sys
+            if sys.platform == 'darwin':
+                try:
+                    import subprocess
+                    subprocess.run(['pbcopy'], input=text.encode('utf-8'), check=True)
+                    return
+                except Exception:
+                    pass
             if wx.TheClipboard.Open():
                 wx.TheClipboard.SetData(wx.TextDataObject(text))
                 wx.TheClipboard.Close()


### PR DESCRIPTION
## Summary

`wx.TextDataObject` on macOS puts text as `public.utf16-plain-text` (raw UTF-16 bytes). Native apps like Messages treat the raw bytes as single-byte characters, printing a space between every letter — every null byte in the UTF-16 encoding appears as a visible space character.

Fix: use `pbcopy` on macOS (the system clipboard utility which writes `NSPasteboardTypeString` via UTF-8 stdin), fall back to `wx.TextDataObject` on Windows where it works correctly.

Scope of changes:
- New `_copy_text_to_clipboard()` static helper in `ImageDescriberFrame`
- Copy Description, Copy Image Path, all four install-command clipboard copies now use the helper
- `viewer_components.py` Copy Text button fixed the same way
- For Copy Image + Description composite on macOS, uses `public.utf8-plain-text` `CustomDataObject` instead of `TextDataObject`

## Test plan

- [ ] Copy Description → paste in Messages, Notes, TextEdit — no spaces between letters
- [ ] Copy Image Path → paste in Terminal — path pastes correctly
- [ ] Copy Text button in viewer → paste in Messages — no encoding artifacts
- [ ] Copy Image + Description → paste text portion in Messages — clean text
- [ ] On Windows (or with wx fallback path) — text still copies correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)