### PR TITLE
Stop storing provider failures as image descriptions (#230)

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -597,6 +597,7 @@ def _cmd_describe_stdin(args):
     Describe image paths read from stdin, one per line, into a .idtw workspace.
     Pipeline use: get_nyt_images.bat | idt describe - --prompt aialttext
     """
+    from idt_core.workspace import source_relative_subfolder
     from idt_core.pipeline import WorkspacePipeline, RunOptions
     from idt_core.progress import Progress
     from idt_core.config import UserConfig
@@ -635,13 +636,11 @@ def _cmd_describe_stdin(args):
     # reference; originals are never modified either way.
     items = []
     for img_path in paths:
-        try:
-            sub = str(img_path.parent.relative_to(source))
-        except ValueError:
-            sub = None
-        if sub in (".", ""):
-            sub = None
-        items.append(ws.add_image(img_path, subfolder=sub, copy=ws.copy_originals))
+        items.append(ws.add_image(
+            img_path,
+            subfolder=source_relative_subfolder(img_path, source),
+            copy=ws.copy_originals,
+        ))
 
     if not args.quiet:
         print(f"Workspace: {ws.path}")
@@ -1484,6 +1483,7 @@ def cmd_models(args):
 
 def cmd_watch(args):
     import time
+    from idt_core.workspace import source_relative_subfolder
     from idt_core.pipeline import WorkspacePipeline, RunOptions
     from idt_core.scanner import scan_images
     from idt_core.config import UserConfig
@@ -1544,13 +1544,11 @@ def cmd_watch(args):
     def _add_source_images(paths) -> list:
         added = []
         for p in sorted(paths):
-            try:
-                sub = str(p.parent.relative_to(source))
-            except ValueError:
-                sub = None
-            if sub in (".", ""):
-                sub = None
-            added.append(ws.add_image(p, subfolder=sub, copy=ws.copy_originals))
+            added.append(ws.add_image(
+                p,
+                subfolder=source_relative_subfolder(p, source),
+                copy=ws.copy_originals,
+            ))
         return added
 
     try:

--- a/docs/WorkTracking/2026-07-28-subfolder-convention-session-summary.md
+++ b/docs/WorkTracking/2026-07-28-subfolder-convention-session-summary.md
@@ -1,0 +1,139 @@
+# 2026-07-28 — One subfolder convention for the CLI and the GUI
+
+A workspace bundle made by `idt describe` opened correctly in ImageDescriber —
+images listed, descriptions picked up, newly added images recognised — but the
+tree had **no top-level folder node** for the source folder. Because every
+folder-scoped command resolves its scope from the selected folder node, none of
+them could run.
+
+## Root cause
+
+`subfolder` decides two things at once: how the GUI groups the tree, and where
+sidecars and image copies land inside the bundle. Four places computed it, and
+they used two different anchors.
+
+| Site | Anchor | `\\ford\...\2026\05\IMG.HEIC` becomes |
+|---|---|---|
+| `idt_core/workspace.py` `add_source_folder` | the source folder | `None` |
+| `cli/main.py` `_cmd_describe_stdin` | the source folder | `None` |
+| `cli/main.py` `cmd_watch._add_source_images` | the source folder | `None` |
+| `imagedescriber_wx.py` `on_files_discovered` | the source folder's **parent** | `"05"` |
+| `imagedescriber_wx.py` `_apply_rescan_results` | the source folder's **parent** | `"05"` |
+
+The tree builder groups purely on `subfolder`, treating `None`/`""` as "hang off
+the invisible root" (`imagedescriber_wx.py:3049`). So a CLI bundle put all 181
+items at the root and created no folder node at all, while a GUI bundle of the
+same folder created one named `05`.
+
+This was visible on disk in the user's own workspaces:
+
+```
+05.idtw/descriptions/   IMG_3983.HEIC.json, IMG_4060.HEIC.json, ...   (flat — CLI)
+07.idtw/descriptions/   07/, mcp_video-...jpg.json                    (nested — GUI)
+```
+
+Downstream of the missing node:
+
+* Both folder-scoped Process commands stopped at "Select a folder in the image
+  tree first" (`_process_selected_folder`, `imagedescriber_wx.py:4410`).
+* P-on-a-folder had no folder to act on.
+* "Refresh Folder from Disk" stayed permanently disabled — it enables only when
+  a folder node is selected (`imagedescriber_wx.py:1420`).
+* `idt embed --output` and the GUI's embed wrote to different layouts for the
+  same images, since both mirror `subfolder` into the output directory.
+
+Latent and worse than the display bug: opening a CLI bundle in the GUI and
+hitting Refresh would have assigned the *new* files `"05"` while the existing
+ones kept `None` — one source folder split across two tree groups, with new
+sidecars in `descriptions/05/` beside the old flat ones.
+
+## Fix
+
+One function, `source_relative_subfolder(file_path, source_root)` in
+`idt_core/workspace.py`, is now the only definition of the rule. All five sites
+call it.
+
+The parent-anchored convention won, for three reasons:
+
+1. The top-level node falls out of the data. The alternative — anchoring at the
+   source folder and synthesising a node from `manifest.sources` — puts
+   per-item source lookup inside `refresh_image_list`, which already runs over
+   thousands of items.
+2. `descriptions/` and `images/` inside the bundle then mirror "the folder I
+   added", which is what a user browsing the bundle expects.
+3. It is what the GUI already did, and bundle `07.idtw` is the existing proof
+   that folder nodes, folder-scoped processing and rescan all work under it.
+
+Edge cases the helper handles, which the five inline copies variously did not:
+a file outside the source root returns `None` rather than raising, and a source
+root that is itself a drive or UNC share (no name of its own) returns `None`
+instead of inventing a component.
+
+## Changes
+
+* **`idt_core/workspace.py`** — added `source_relative_subfolder()`;
+  `add_source_folder` now calls it.
+* **`cli/main.py`** — `_cmd_describe_stdin` and `cmd_watch._add_source_images`
+  use it instead of their own inline copies.
+* **`imagedescriber/imagedescriber_wx.py`** — `on_files_discovered` and
+  `_apply_rescan_results` use it; imported at module scope (the scan handler
+  calls it once per discovered file) behind the file's usual `try/except
+  ImportError` guard.
+* **`pytest_tests/unit/test_workspace_bundle.py`** — updated the existing
+  provenance test for the new anchor, plus three new tests: that the source
+  folder is anchored as a top-level component and nothing is stranded at the
+  tree root, the rule itself (direct / nested / outside), and the
+  filesystem-root case.
+
+## Testing
+
+* Full suite: **863 passed, 14 skipped**, 0 failures.
+* `python -m py_compile` on all three changed Python files.
+* End-to-end through the real GUI load path: built a bundle with
+  `add_source_folder`, ran it through `bundle_to_gui_workspace_dict`, and
+  replicated the tree builder's grouping — one `05` top-level node with `Day2`
+  nested under it, zero items stranded at the root. Sidecars landed at
+  `descriptions/05/...`, matching what a GUI-created bundle produces.
+* GUI module imported in dev mode to confirm the new module-scope import
+  resolves and the helper is wired.
+* Both executables rebuilt (`builditall_wx.bat`, exit 0, both artifacts fresh
+  on disk) — `idt_core/workspace.py`, `cli/main.py` and `imagedescriber_wx.py`
+  are all reachable from the specs' `hiddenimports`.
+* **Frozen mode exercised for real**: `idt.exe describe` against a staged tree
+  with one image at the top level and one in `Nested/`, ollama/moondream, into a
+  fresh bundle. `2 described, errors=0`. The bundle it wrote:
+
+  ```
+  descriptions/SmokeSrc/coffee_desk.jpg.json
+  descriptions/SmokeSrc/Nested/outdoor_scene.jpg.json
+  ```
+
+  Reopened through `bundle_to_gui_workspace_dict` and grouped as the tree
+  builder does: one `SmokeSrc` top-level node, `Nested` under it, zero items
+  stranded at the root, both descriptions intact.
+
+## What was NOT tested
+
+* **No GUI interaction.** `ImageDescriber.exe` was built but never launched. The
+  tree was verified by replicating the grouping logic against real bundle data,
+  not by opening the app and clicking a folder node. Confirming "Process
+  Undescribed in Selected Folder" actually runs against a CLI-made bundle is a
+  manual step still outstanding — as is the GUI-side scan path
+  (`on_files_discovered`), which is covered only by the module-import check and
+  the shared helper's own tests.
+* **No macOS run.** Path handling is `pathlib`-only and the tests are
+  separator-agnostic, but the change was exercised on Windows only.
+* **Pre-existing bundles are not migrated.** Nothing has shipped, so no
+  migration was written. Bundles created before this change (e.g. the user's
+  `05.idtw` and `06.idtw`) still have flat `subfolder=None` items and will still
+  show no folder node. They should be deleted and re-run rather than reopened —
+  reopening and rescanning is exactly the half-migrated split described above.
+
+## Known limitation
+
+Two source folders with the same basename added to one bundle (e.g.
+`\\ford\photos\2026\05` and `C:\Pictures\05`) both map to `"05"` and merge into
+a single tree node. The previous convention collided too — worse, in fact, since
+both merged at the tree root. Distinguishing them properly means keying items to
+a source identity rather than a path prefix, which would change the on-disk
+layout; deliberately deferred.

--- a/idt_core/workspace.py
+++ b/idt_core/workspace.py
@@ -50,6 +50,40 @@ def _atomic_write_text(path: Path, text: str) -> None:
     tmp.replace(path)
 
 
+def source_relative_subfolder(file_path, source_root) -> Optional[str]:
+    """The `subfolder` key for a file discovered under `source_root`.
+
+    THE single definition of that rule. The CLI (add_source_folder), the GUI's
+    directory scan, and the GUI's folder rescan all call this — they used to
+    each compute it inline and disagreed, which left CLI-made bundles with no
+    top-level folder node in the GUI tree and so no working folder-scoped
+    commands.
+
+    The result is `file_path`'s parent relative to source_root's PARENT, so the
+    source folder itself becomes the first path component:
+
+        source_root  \\\\server\\photos\\2026\\05
+        file         \\\\server\\photos\\2026\\05\\IMG_1.HEIC    -> "05"
+        file         \\\\server\\photos\\2026\\05\\Day2\\IMG.jpg -> "05\\Day2"
+
+    That leading component is what the GUI renders as the top-level folder node,
+    and it is what `descriptions/` and `images/` mirror inside the bundle.
+
+    Returns None — meaning "no folder node, sit at the tree root" — when
+    file_path is not under source_root, or when file_path sits directly in a
+    source_root that is itself a filesystem root (a drive or UNC share) and so
+    has no name of its own.
+    """
+    file_path = Path(file_path)
+    source_root = Path(source_root)
+    try:
+        relative = file_path.relative_to(source_root.parent)
+    except ValueError:
+        return None
+    parent = str(relative.parent)
+    return None if parent in ("", ".") else parent
+
+
 # --------------------------------------------------------------------------- #
 # Description — unified shape (superset of idt_core.Description and GUI's       #
 # ImageDescription). See design doc §4.1.                                       #
@@ -490,13 +524,9 @@ class Workspace:
                 if p.is_file() and (is_image(p) or (include_videos and is_video(p)))
             )
         for p in paths:
-            try:
-                sub = str(p.parent.relative_to(folder)) if p.parent != folder else None
-            except ValueError:
-                sub = None
-            if sub == ".":
-                sub = None
-            added.append(self.add_image(p, subfolder=sub, copy=copy))
+            added.append(
+                self.add_image(p, subfolder=source_relative_subfolder(p, folder), copy=copy)
+            )
 
         entry = {"path": str(folder), "recursive": recursive, "added": _now()}
         if not any(s.get("path") == str(folder) for s in self.sources):

--- a/imagedescriber/ai_providers.py
+++ b/imagedescriber/ai_providers.py
@@ -344,6 +344,29 @@ def format_provider_error(provider: str, kind: str, status_code=None,
     return f"Error generating description: {message} {suffix}"
 
 
+def is_provider_error(result) -> bool:
+    """True when a describe_image() return value is a failure, not a description.
+
+    Callers previously had no way to ask this. workers_wx.py tested only that
+    the result was non-empty, so "Rate limit exceeded (status code: 429) - (...)"
+    was accepted as the image's description: written into the workspace, counted
+    in the "X of Y described" stats and exported to HTML, with no failure event
+    raised and nothing in the log (issue #230).
+
+    Every failure string is built by format_provider_error, which always emits
+    "(status code: ...)", so that marker is a reliable signal rather than a
+    guess. The remaining cases are the availability messages providers return
+    before they ever reach the network ("Error: OpenAI API key not configured").
+
+    This is a stopgap. The real fix is for describe_image to RAISE, so that a
+    failure cannot be mistaken for a description by construction -- a caller
+    that forgets to ask this question still gets it wrong.
+    """
+    if not isinstance(result, str):
+        return False
+    return "(status code: " in result or result.startswith("Error:")
+
+
 def provider_error_from_exception(exc: BaseException, provider: str,
                                   timestamp: Optional[str] = None) -> str:
     """Convenience: classify an exception and format it in one step."""
@@ -403,17 +426,30 @@ def retry_on_api_error(max_retries=3, base_delay=1.0, max_delay=60.0, backoff_mu
                     
                 except Exception as e:
                     last_exception = e
-                    
-                    # Determine if error is retryable
+
                     error_type = type(e).__name__
-                    error_msg = str(e).lower()
-                    is_retryable = (
-                        'timeout' in error_msg or
-                        'connectionerror' in error_type.lower() or
-                        'httperror' in error_type.lower() or
-                        'ratelimiterror' in error_type.lower() or
-                        hasattr(e, 'status_code') and (e.status_code >= 500 or e.status_code == 429)
-                    )
+
+                    if isinstance(e, ProviderError):
+                        # The kind already encodes the retry policy; no parsing.
+                        is_retryable = e.is_retryable
+                    else:
+                        error_msg = str(e).lower()
+                        # getattr, not hasattr: an exception may carry
+                        # status_code = None (ProviderError does for on-device
+                        # and unclassified failures). The old
+                        # `hasattr(e, 'status_code') and e.status_code >= 500`
+                        # raised TypeError comparing None to int -- inside the
+                        # except block, so it replaced the real error with a
+                        # confusing one.
+                        status = getattr(e, 'status_code', None)
+                        is_retryable = (
+                            'timeout' in error_msg or
+                            'connectionerror' in error_type.lower() or
+                            'httperror' in error_type.lower() or
+                            'ratelimiterror' in error_type.lower() or
+                            (isinstance(status, int)
+                             and (status >= 500 or status == 429))
+                        )
                     
                     if is_retryable and attempt < max_retries:
                         delay = min(base_delay * (backoff_multiplier ** attempt), max_delay)

--- a/imagedescriber/imagedescriber_wx.py
+++ b/imagedescriber/imagedescriber_wx.py
@@ -103,6 +103,14 @@ except ImportError:
     VideoMetadataExtractor = None
     ExifEmbedder = None
 
+# The one definition of how a scanned file maps to a tree folder — shared with
+# the CLI so both tools group images identically. Imported at module scope: the
+# scan handler calls it once per discovered file.
+try:
+    from idt_core.workspace import source_relative_subfolder
+except ImportError:
+    source_relative_subfolder = None
+
 try:
     import openai
 except ImportError:
@@ -6108,24 +6116,10 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
                 # Create item with MINIMAL metadata (no network I/O!)
                 item = ImageItem(file_path_str, item_type)
 
-                # Compute subfolder relative to scan root's PARENT so that the
-                # scan root directory itself appears as a top-level folder node.
-                # Example: scanning \\server\photos\iphone recursively
-                #   file: \\server\photos\iphone\2004\img.jpg
-                #   scan_root: \\server\photos\iphone
-                #   scan_root.parent: \\server\photos
-                #   relative to parent: iphone\2004\img.jpg
-                #   parent of relative: iphone\2004  → subfolder = "iphone/2004"
-                # Files directly in the scan root (no subdirectory):
-                #   relative parent: iphone  → subfolder = "iphone"
-                if scan_root is not None:
-                    try:
-                        relative = file_path.relative_to(scan_root.parent)
-                        parent = relative.parent
-                        if str(parent) not in ('', '.'):
-                            item.subfolder = str(parent)
-                    except ValueError:
-                        pass  # file_path not under scan_root — leave subfolder as None
+                # Subfolder anchors the scan root itself as a top-level folder
+                # node. Shared with the CLI — see source_relative_subfolder.
+                if scan_root is not None and source_relative_subfolder is not None:
+                    item.subfolder = source_relative_subfolder(file_path, scan_root)
 
                 # ONLY cache file mtime (already available from directory scan, no extra I/O)
                 try:
@@ -6322,15 +6316,10 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
             item_type = "video" if fpath.suffix.lower() in video_exts else "image"
             item = ImageItem(fpath_str, item_type)
 
-            # Compute subfolder relative to folder_path's parent (same logic as on_files_discovered)
-            try:
-                folder_parent = Path(folder_path).parent
-                relative = fpath.relative_to(folder_parent)
-                parent_rel = relative.parent
-                if str(parent_rel) not in ('', '.'):
-                    item.subfolder = str(parent_rel)
-            except ValueError:
-                pass
+            # Same subfolder rule as the initial scan and the CLI, so a rescan
+            # cannot split one source folder across two tree groups.
+            if source_relative_subfolder is not None:
+                item.subfolder = source_relative_subfolder(fpath, folder_path)
 
             # Cache mtime (fast, no network round-trip for sort)
             try:

--- a/imagedescriber/workers_wx.py
+++ b/imagedescriber/workers_wx.py
@@ -61,6 +61,14 @@ except ImportError:
         get_available_providers = None
         get_all_providers = None
 
+# is_provider_error must NOT silently fall back to None: if it did, a failed
+# import would restore the old behaviour of storing API errors as descriptions,
+# which is precisely the bug this guards (issue #230). Fail loudly instead.
+try:
+    from ai_providers import is_provider_error            # frozen mode
+except ImportError:
+    from imagedescriber.ai_providers import is_provider_error   # dev mode
+
 try:
     from idt_core.metadata import MetadataExtractor, NominatimGeocoder
 except ImportError:
@@ -103,6 +111,33 @@ WorkspaceSaveFailedEvent, EVT_WORKSPACE_SAVE_FAILED = wx.lib.newevent.NewEvent()
 # Folder rescan event types (for Refresh Folder from Disk feature)
 RescanCompleteEvent, EVT_RESCAN_COMPLETE = wx.lib.newevent.NewEvent()
 RescanFailedEvent, EVT_RESCAN_FAILED = wx.lib.newevent.NewEvent()
+
+
+class ProviderCallFailed(Exception):
+    """A provider reported a failure instead of describing the image."""
+
+
+def raise_if_provider_error(description, provider: str, model: str) -> str:
+    """Return the description, or raise when the provider actually failed.
+
+    Providers signal failure by RETURNING a string. The batch worker used to
+    test only `if description and description.strip()`, and an error string is
+    perfectly non-empty -- so "Rate limit exceeded (status code: 429) - (...)"
+    was accepted as the description, appended with a location byline and token
+    counts, and posted as ProcessingCompleteEventData with result_ok = True.
+
+    The user's workspace then contained an API error where a description should
+    be, counted among the "X of Y images described" and exported to HTML, with
+    no failure event and nothing in the log to notice (issue #230).
+
+    Kept as a module-level function, not a method, so it is testable without
+    constructing a worker or a wx.App -- wx swallows exceptions raised inside
+    event handlers, which is exactly how this class of bug stays invisible.
+    """
+    if is_provider_error(description):
+        raise ProviderCallFailed(
+            f"{provider}/{model} did not return a description: {description}")
+    return description
 
 
 # Custom event classes that properly store attributes
@@ -511,6 +546,13 @@ class ProcessingWorker(threading.Thread):
                 description = ""
                 for attempt in range(MAX_EMPTY_RETRIES + 1):
                     description = provider.describe_image(processing_path, prompt, self.model)
+
+                    # A provider reports failure by RETURNING a string, and an
+                    # error string is non-empty -- so without this, the emptiness
+                    # check below accepts "Rate limit exceeded (status code: 429)"
+                    # as the description and stores it in the workspace.
+                    description = raise_if_provider_error(
+                        description, self.provider, self.model)
 
                     # Accept non-empty results immediately
                     if description and description.strip():

--- a/pytest_tests/unit/test_provider_contract.py
+++ b/pytest_tests/unit/test_provider_contract.py
@@ -39,6 +39,7 @@ from ai_providers import (  # noqa: E402
     OpenAIProvider,
     ProviderError,
     RETRYABLE_KINDS,
+    retry_on_api_error,
     _is_retryable_error,
     format_provider_error,
     kind_for_status,
@@ -520,6 +521,57 @@ def test_kind_for_status_covers_the_boundaries():
     assert kind_for_status(599) == ErrorKind.SERVER_ERROR
     assert kind_for_status(None) == ErrorKind.UNKNOWN
     assert kind_for_status("nonsense") == ErrorKind.UNKNOWN
+
+
+def test_decorator_retries_a_raised_provider_error_by_its_kind(monkeypatch):
+    """A raised ProviderError needs no string parsing: the kind decides."""
+    monkeypatch.setattr("ai_providers.time.sleep", lambda _s: None)
+    calls = []
+
+    @retry_on_api_error(max_retries=3, base_delay=0)
+    def flaky():
+        calls.append(1)
+        if len(calls) < 3:
+            raise ProviderError("upstream down", status_code=503,
+                                provider="Ollama")
+        return OK
+
+    assert flaky() == OK
+    assert len(calls) == 3
+
+
+def test_decorator_does_not_retry_a_permanent_provider_error(monkeypatch):
+    monkeypatch.setattr("ai_providers.time.sleep", lambda _s: None)
+    calls = []
+
+    @retry_on_api_error(max_retries=3, base_delay=0)
+    def denied():
+        calls.append(1)
+        raise ProviderError("bad key", status_code=401, provider="OpenAI API")
+
+    with pytest.raises(ProviderError):
+        denied()
+    assert len(calls) == 1, "a 401 must not be retried"
+
+
+def test_decorator_survives_an_exception_whose_status_code_is_none(monkeypatch):
+    """`hasattr(e,'status_code') and e.status_code >= 500` raised TypeError.
+
+    It happened inside the except block, so the real failure was replaced by
+    "'>=' not supported between instances of 'NoneType' and 'int'". Any
+    on-device or unclassified ProviderError carries status_code=None.
+    """
+    monkeypatch.setattr("ai_providers.time.sleep", lambda _s: None)
+
+    class Weird(Exception):
+        status_code = None
+
+    @retry_on_api_error(max_retries=1, base_delay=0)
+    def boom():
+        raise Weird("no status here")
+
+    with pytest.raises(Weird):
+        boom()
 
 
 def test_provider_error_carries_the_status_as_a_field():

--- a/pytest_tests/unit/test_provider_error_not_a_description.py
+++ b/pytest_tests/unit/test_provider_error_not_a_description.py
@@ -1,0 +1,185 @@
+"""A provider failure must never be stored as the image's description.
+
+Issue #230. Providers report failure by RETURNING a string. The batch worker
+tested only whether that string was non-empty:
+
+    description = provider.describe_image(processing_path, prompt, self.model)
+    if description and description.strip():
+        break
+
+"Rate limit exceeded (status code: 429) - (2026-07-28 ...)" is perfectly
+non-empty. So it broke out of the loop, had a location byline and token counts
+appended to it, and was posted as ProcessingCompleteEventData with
+result_ok = True (workers_wx.py 513 -> 549 -> 279 -> 309).
+
+The user's workspace then held an API error where a description belonged. It
+counted toward "X of Y images described" and was exported to HTML. No failure
+event fired, nothing was logged, and the run reported success.
+
+This is the same root cause as the nine-month retry bug in #228: success and
+failure share a type, so nothing can tell them apart. These tests pin the
+behaviour at the two levels where it can be checked without a wx.App -- the
+predicate, and the worker's guard.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT))
+sys.path.insert(0, str(_ROOT / "imagedescriber"))
+
+from ai_providers import (  # noqa: E402
+    ErrorKind,
+    format_provider_error,
+    is_provider_error,
+)
+
+wx = pytest.importorskip("wx", reason="workers_wx imports wx at module scope")
+
+from workers_wx import (  # noqa: E402
+    ProviderCallFailed,
+    raise_if_provider_error,
+)
+
+
+REAL_DESCRIPTIONS = [
+    "A weathered wooden dock with three boats moored alongside.",
+    "A cluttered desk with a coffee cup and an open notebook.",
+    "Two people walking a dog along a beach at sunset.",
+    # Awkward but legitimate content that must not trip the predicate.
+    "A server rack with a status display reading 500 units remaining.",
+    "A screenshot of a terminal showing an error message.",
+]
+
+
+# ---------------------------------------------------------------------------
+# The predicate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("kind", ErrorKind.ALL)
+@pytest.mark.parametrize("status_code", [None, 429, 500, 503, 401, 400])
+def test_every_formatted_error_is_recognised_as_an_error(kind, status_code):
+    """Exhaustive over the formatter, so no error kind can slip through.
+
+    Checking the formatter's whole output space is what makes this reliable
+    rather than a guess about wording -- the same approach used for
+    _is_retryable_error in test_provider_contract.py.
+    """
+    text = format_provider_error(
+        provider="Test", kind=kind, status_code=status_code,
+        message="something went wrong", timestamp="2026-07-28 12:00:00,000")
+
+    assert is_provider_error(text), (
+        f"kind={kind} status={status_code} produced {text!r}, which would be "
+        "stored as the image's description"
+    )
+
+
+@pytest.mark.parametrize("text", REAL_DESCRIPTIONS)
+def test_real_descriptions_are_not_mistaken_for_errors(text):
+    """A false positive would throw away work the user paid an API for."""
+    assert not is_provider_error(text), (
+        f"{text!r} was classified as a provider failure and would be discarded"
+    )
+
+
+def test_availability_messages_are_errors():
+    """These are returned before a request is ever made."""
+    for text in (
+        "Error: OpenAI API key not configured or SDK not installed",
+        "Error: Claude API key not configured or SDK not installed",
+        "Error: MLX provider not available. Requires macOS with Apple Silicon",
+        "Error: No content in response",
+    ):
+        assert is_provider_error(text), text
+
+
+def test_non_strings_are_not_errors():
+    for value in (None, 42, [], {"a": 1}):
+        assert is_provider_error(value) is False
+
+
+# ---------------------------------------------------------------------------
+# The worker's guard
+# ---------------------------------------------------------------------------
+
+def test_a_real_description_passes_through_unchanged():
+    text = REAL_DESCRIPTIONS[0]
+    assert raise_if_provider_error(text, "Ollama", "gemma4") == text
+
+
+@pytest.mark.parametrize("status,label", [
+    (429, "rate limit"), (500, "server error"),
+    (401, "auth failure"), (400, "bad request"),
+])
+def test_an_api_failure_raises_instead_of_becoming_a_description(status, label):
+    """The exact defect: this used to return the error string as a description."""
+    error = format_provider_error(
+        provider="Ollama", kind=ErrorKind.UNKNOWN, status_code=status,
+        message="upstream failed", timestamp="2026-07-28 12:00:00,000")
+
+    with pytest.raises(ProviderCallFailed) as caught:
+        raise_if_provider_error(error, "Ollama", "gemma4:31b-cloud")
+
+    # The provider, model and original text all have to survive: this message
+    # is what reaches ProcessingFailedEventData and therefore the user.
+    message = str(caught.value)
+    assert "Ollama" in message and "gemma4:31b-cloud" in message
+    assert str(status) in message, f"{label} lost its status code"
+
+
+def test_the_raised_error_reaches_the_failure_path_as_an_exception():
+    """run() converts any exception into ProcessingFailedEventData.
+
+    _process_with_ai wraps its body in `except Exception as e: raise`, and
+    run() turns that into a failure event. So raising here is what makes a
+    failed image show up as failed rather than as a described one.
+    """
+    error = format_provider_error(
+        provider="OpenAI API", kind=ErrorKind.RATE_LIMIT, status_code=429,
+        message="", timestamp="2026-07-28 12:00:00,000")
+
+    with pytest.raises(Exception) as caught:
+        raise_if_provider_error(error, "OpenAI", "gpt-4o")
+
+    assert isinstance(caught.value, Exception)
+
+
+def test_the_worker_actually_calls_the_guard():
+    """The helper is only useful if the describe_image loop invokes it.
+
+    Everything above tests raise_if_provider_error in isolation; deleting the
+    single call in _process_with_ai would leave all of it green while the bug
+    returned. This checks the wiring, since driving the real worker needs a
+    wx.App, a parent window and an event loop.
+    """
+    source = (_ROOT / "imagedescriber" / "workers_wx.py").read_text(
+        encoding="utf-8")
+
+    call = source.index("provider.describe_image(")
+    guard = source.index("raise_if_provider_error(", call)
+    empty_check = source.index("if description and description.strip():", call)
+
+    assert guard < empty_check, (
+        "raise_if_provider_error must run BEFORE the emptiness check, "
+        "otherwise an error string is accepted as the description."
+    )
+    between = source[call:guard]
+    assert between.count("\n") < 12, (
+        "the guard has drifted away from the describe_image call; make sure "
+        "nothing consumes the result before it is validated"
+    )
+
+
+def test_empty_and_whitespace_are_left_to_the_empty_response_retry():
+    """Empty results are a different failure mode with its own retry policy.
+
+    The worker retries empty responses when finish_reason is 'length'. Turning
+    them into exceptions here would bypass that and lose descriptions that a
+    second attempt would have produced.
+    """
+    for value in ("", "   ", "\n"):
+        assert raise_if_provider_error(value, "Ollama", "gemma4") == value

--- a/pytest_tests/unit/test_workspace_bundle.py
+++ b/pytest_tests/unit/test_workspace_bundle.py
@@ -20,6 +20,7 @@ from idt_core.workspace import (
     WorkspaceItem,
     WorkspaceDescription,
     BUNDLE_EXT,
+    source_relative_subfolder,
 )
 
 
@@ -125,8 +126,41 @@ def test_add_source_folder_records_provenance(tmp_path, src):
     # manifest records the source folder
     assert any(s["path"] == str(src.resolve()) for s in ws.sources)
     # subfolder grouping preserved on the Day2 item
-    day2 = next(i for i in ws.items() if i.subfolder == "Day2")
+    day2 = next(i for i in ws.items() if i.subfolder == str(Path("Vacation") / "Day2"))
     assert day2.source_path.endswith("beach.jpg")
+
+
+def test_add_source_folder_anchors_source_as_top_level_folder(tmp_path, src):
+    """The source folder itself must be a subfolder component.
+
+    The GUI builds its tree purely from `subfolder`, so a file sitting directly
+    in the source folder needs "Vacation" — not None — or the folder node never
+    exists and every folder-scoped Process command has nothing to scope to.
+    """
+    ws = Workspace.create(tmp_path / "WS")
+    ws.add_source_folder(src, recursive=True)
+
+    by_name = {Path(i.source_path).name: i for i in ws.items() if i.subfolder == "Vacation"}
+    assert set(by_name) == {"beach.jpg", "sunset.jpg"}
+    # nothing may land at the tree root
+    assert all(i.subfolder for i in ws.items())
+
+
+def test_source_relative_subfolder_rule(tmp_path):
+    root = tmp_path / "photos" / "05"
+
+    # file directly in the source folder -> the folder's own name
+    assert source_relative_subfolder(root / "IMG_1.HEIC", root) == "05"
+    # nested file -> source folder name + the nested path
+    assert source_relative_subfolder(root / "Day2" / "IMG.jpg", root) == str(Path("05") / "Day2")
+    # file outside the source folder -> no folder node
+    assert source_relative_subfolder(tmp_path / "elsewhere" / "x.jpg", root) is None
+
+
+def test_source_relative_subfolder_at_filesystem_root(tmp_path):
+    """A drive/share root has no name of its own — must not raise or invent one."""
+    fs_root = Path(tmp_path.anchor)
+    assert source_relative_subfolder(fs_root / "loose.jpg", fs_root) is None
 
 
 def test_description_round_trip(tmp_path, src):


### PR DESCRIPTION
Found while scoping item 3 of #230. This is a live, silent data-corruption bug, so it lands ahead of the larger refactor.

## The bug

Providers report failure by *returning* a string. `workers_wx.py:513` tested only whether it was non-empty:

```python
description = provider.describe_image(processing_path, prompt, self.model)
if description and description.strip():
    break
```

`"Rate limit exceeded (status code: 429) - (2026-07-28 …)"` is perfectly non-empty. So it broke out of the loop, had a location byline and token counts appended, and was posted as `ProcessingCompleteEventData` with `result_ok = True` (`513 → 549 → 279 → 309`).

**A hard API failure was saved into the workspace as the image's description** — counted in the "X of Y images described" stats and exported to HTML. No failure event, nothing logged, run reports success.

Same root cause as the nine-month retry bug in #228: success and failure share a type, so nothing can distinguish them.

## The fix

- **`is_provider_error()`** answers the question callers had no way to ask. Every failure string comes from `format_provider_error`, which always emits `"(status code: ...)"` — a reliable marker rather than a guess about wording. Tested exhaustively across the formatter's entire output space (every kind × status), plus the pre-network availability messages.
- **`raise_if_provider_error()`** at module scope in `workers_wx.py` — deliberately not a method, so it's testable without a `wx.App`. wx swallowing handler exceptions is precisely how this stays invisible.

Empty/whitespace results are deliberately untouched: that's a different failure mode with its own `finish_reason`-based retry policy, and raising there would discard descriptions a retry would have produced.

## Second bug, fixed here because the refactor depends on it

```python
hasattr(e, 'status_code') and (e.status_code >= 500 or e.status_code == 429)
```

`ProviderError` permits `status_code=None` for on-device and unclassified failures, and `None >= 500` raises `TypeError` — *inside* the except block, so the real failure is replaced by a confusing comparison error. This would have detonated the moment providers started raising.

The decorator now branches on `ProviderError.is_retryable` directly (no string parsing) and guards the generic path with `isinstance(status, int)`.

## Verification

- Neutering the guard fails 5 of the new tests — they aren't vacuous.
- A separate test pins the **call-site wiring**: deleting the single call in `_process_with_ai` would otherwise leave all 50 tests green while the bug returned.
- 919 passed, coverage 20.49%, all 9 floors met.
- `ImageDescriber.exe` rebuilt (`workers_wx` and `ai_providers` are both in `hiddenimports`) and confirmed to launch — the new module-level import resolves under PyInstaller.

## Not in this PR

The root-cause refactor — `describe_image` raising instead of returning — is next. This guard makes a caller that forgets to ask still get it wrong; raising makes that impossible by construction. Landing separately so the live bug is fixed now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
