### PR TITLE
Make providers raise ProviderError instead of returning error strings (#230)

### DIFF
--- a/imagedescriber/ai_providers.py
+++ b/imagedescriber/ai_providers.py
@@ -200,10 +200,15 @@ class ErrorKind:
     INVALID_REQUEST = "invalid_request"
     SERVER_ERROR = "server_error"
     TIMEOUT = "timeout"
+    #: The provider cannot run at all -- no API key, SDK missing, wrong OS.
+    #: Distinct from AUTH: nothing was ever sent, so there is no status code
+    #: and no request to blame. Permanently non-retryable; retrying a provider
+    #: that is not configured burns the whole batch to no effect.
+    UNAVAILABLE = "unavailable"
     UNKNOWN = "unknown"
 
-    ALL = ("rate_limit", "auth", "invalid_request",
-           "server_error", "timeout", "unknown")
+    ALL = ("rate_limit", "auth", "invalid_request", "server_error",
+           "timeout", "unavailable", "unknown")
 
 
 #: Kinds worth another attempt. This is the ONLY definition of that policy;
@@ -341,6 +346,11 @@ def format_provider_error(provider: str, kind: str, status_code=None,
         return f"Server error from {provider} {suffix}"
     if kind == ErrorKind.TIMEOUT:
         return f"Request timeout - try again later {suffix}"
+    if kind == ErrorKind.UNAVAILABLE:
+        # No request was made, so a status code would be a fiction. The "Error:"
+        # prefix is retained because is_provider_error() recognises it and
+        # these strings predate the formatter.
+        return f"Error: {message}"
     return f"Error generating description: {message} {suffix}"
 
 
@@ -378,6 +388,47 @@ def provider_error_from_exception(exc: BaseException, provider: str,
         message=str(exc),
         timestamp=timestamp,
     )
+
+
+def raise_provider_error(provider: str, kind: str, status_code=None,
+                         message: str = "", timestamp: Optional[str] = None):
+    """Signal a provider failure the only way callers cannot ignore.
+
+    describe_image() used to RETURN these strings. That made a failure
+    indistinguishable from a description by type, and it cost twice:
+
+      * retry_on_api_error had to infer "transient" from wording. Ollama said
+        "Error: HTTP 500" while the decorator matched "status code: 5", so
+        every Ollama 5xx was permanent for nine months (issue #228).
+      * workers_wx checked only that the result was non-empty, so an error
+        string was stored as the image's description, counted in the
+        "X of Y described" stats and exported to HTML (issue #230).
+
+    Raising removes the class of bug rather than guarding against it: a caller
+    that forgets to handle failure now gets a traceback instead of silently
+    recording nonsense. The message reads exactly as the returned string did,
+    so logs and saved diagnostics stay comparable.
+    """
+    raise ProviderError(
+        format_provider_error(provider=provider, kind=kind,
+                              status_code=status_code, message=message,
+                              timestamp=timestamp),
+        status_code=status_code,
+        provider=provider,
+        kind=kind,
+    )
+
+
+def raise_provider_error_from_exception(exc: BaseException, provider: str,
+                                        timestamp: Optional[str] = None):
+    """Classify an SDK/transport exception and re-raise it as a ProviderError."""
+    kind, status_code = classify_provider_exception(exc)
+    raise ProviderError(
+        provider_error_from_exception(exc, provider, timestamp),
+        status_code=status_code,
+        provider=provider,
+        kind=kind,
+    ) from exc
 
 
 def retry_on_api_error(max_retries=3, base_delay=1.0, max_delay=60.0, backoff_multiplier=2.0):
@@ -654,7 +705,7 @@ class OllamaProvider(AIProvider):
                 # Never hand-write this string: the older "Error: HTTP 500"
                 # wording carried no "(status code: NNN)", so retry_on_api_error
                 # treated every 5xx as permanent for nine months.
-                return format_provider_error(
+                raise_provider_error(
                     provider="Ollama",
                     kind=kind_for_status(response.status_code),
                     status_code=response.status_code,
@@ -662,6 +713,11 @@ class OllamaProvider(AIProvider):
                     timestamp=timestamp,
                 )
 
+        except ProviderError:
+            # Raised by this method's own body. Re-raise unchanged;
+            # the generic handler below would re-wrap it and lose the
+            # kind and status_code it already carries.
+            raise
         except Exception as e:
             # Enhanced error logging for Ollama exceptions
             from datetime import datetime
@@ -693,7 +749,7 @@ class OllamaProvider(AIProvider):
             except Exception as log_error:
                 print(f"  Warning: Could not write to error log: {log_error}")
 
-            return provider_error_from_exception(e, "Ollama", timestamp)
+            raise_provider_error_from_exception(e, "Ollama", timestamp)
 
     def get_last_token_usage(self) -> Optional[Dict]:
         """Return token usage from last API call (if available)"""
@@ -858,7 +914,9 @@ class OpenAIProvider(AIProvider):
     def describe_image(self, image_path: str, prompt: str, model: str) -> str:
         """Generate description using OpenAI SDK with automatic retry and token tracking"""
         if not self.is_available():
-            return "Error: OpenAI API key not configured or SDK not installed"
+            raise_provider_error(
+                provider="OpenAI", kind=ErrorKind.UNAVAILABLE,
+                message="OpenAI API key not configured or SDK not installed")
         
         try:
             # Normalise every image to a resized JPEG before sending to OpenAI.
@@ -1004,6 +1062,11 @@ class OpenAIProvider(AIProvider):
             
             return content
                 
+        except ProviderError:
+            # Raised by this method's own body. Re-raise unchanged;
+            # the generic handler below would re-wrap it and lose the
+            # kind and status_code it already carries.
+            raise
         except Exception as e:
             # Enhanced error logging with detailed diagnostics
             from datetime import datetime
@@ -1063,7 +1126,7 @@ class OpenAIProvider(AIProvider):
                 print(f"  Warning: Could not write to error log: {log_error}")
             
             # One formatter, one classifier -- see format_provider_error.
-            return format_provider_error(
+            raise_provider_error(
                 provider="OpenAI API",
                 kind=kind,
                 status_code=classified_status,
@@ -1221,7 +1284,9 @@ class ClaudeProvider(AIProvider):
     def describe_image(self, image_path: str, prompt: str, model: str) -> str:
         """Generate description using Claude SDK with automatic retry and token tracking"""
         if not self.is_available():
-            return "Error: Claude API key not configured or SDK not installed"
+            raise_provider_error(
+                provider="Claude", kind=ErrorKind.UNAVAILABLE,
+                message="Claude API key not configured or SDK not installed")
         
         try:
             # Read and encode image
@@ -1275,8 +1340,15 @@ class ClaudeProvider(AIProvider):
             # Extract text from content
             if message.content and len(message.content) > 0:
                 return message.content[0].text
-            return "Error: No content in response"
+            raise_provider_error(
+                provider="Claude API", kind=ErrorKind.UNKNOWN,
+                message="no content in response")
                 
+        except ProviderError:
+            # Raised by this method's own body. Re-raise unchanged;
+            # the generic handler below would re-wrap it and lose the
+            # kind and status_code it already carries.
+            raise
         except Exception as e:
             # Enhanced error logging with detailed diagnostics
             from datetime import datetime
@@ -1336,7 +1408,7 @@ class ClaudeProvider(AIProvider):
                 print(f"  Warning: Could not write to error log: {log_error}")
             
             # One formatter, one classifier -- see format_provider_error.
-            return format_provider_error(
+            raise_provider_error(
                 provider="Claude API",
                 kind=kind,
                 status_code=classified_status,
@@ -1554,10 +1626,10 @@ class MLXProvider(AIProvider):
     def describe_image(self, image_path: str, prompt: str, model: str) -> str:
         """Run Metal-accelerated vision inference and return a description string."""
         if not self.is_available():
-            return (
-                "Error: MLX provider not available. "
-                "Requires macOS with Apple Silicon and: pip install mlx-vlm"
-            )
+            raise_provider_error(
+                provider="MLX", kind=ErrorKind.UNAVAILABLE,
+                message="MLX provider not available. Requires macOS with "
+                        "Apple Silicon and: pip install mlx-vlm")
 
         temp_jpeg: Optional[str] = None
         try:
@@ -1574,10 +1646,10 @@ class MLXProvider(AIProvider):
             path_obj = Path(image_path)
             temp_jpeg = self._to_jpeg_tempfile(image_path)
             if not temp_jpeg:
-                return (
-                    f"Error: Could not prepare {path_obj.suffix.upper() or 'image'} "
-                    f"for MLX inference"
-                )
+                raise_provider_error(
+                    provider=f"MLX/{model}", kind=ErrorKind.INVALID_REQUEST,
+                    message=f"could not prepare "
+                            f"{path_obj.suffix.upper() or 'image'} for inference")
             use_path = temp_jpeg
 
             # ---- format prompt for the model's chat template ----
@@ -1619,8 +1691,17 @@ class MLXProvider(AIProvider):
                 'finish_reason': 'stop',     # assume stop; no length info from mlx-vlm
             }
 
-            return text.strip() if text else "Error: MLX returned empty response"
+            if not text or not text.strip():
+                raise_provider_error(
+                    provider=f"MLX/{model}", kind=ErrorKind.UNKNOWN,
+                    message="returned an empty response")
+            return text.strip()
 
+        except ProviderError:
+            # Raised by this method's own body. Re-raise unchanged;
+            # the generic handler below would re-wrap it and lose the
+            # kind and status_code it already carries.
+            raise
         except Exception as exc:
             import traceback
             error_type = type(exc).__name__
@@ -1630,7 +1711,7 @@ class MLXProvider(AIProvider):
             # MLX runs on-device, so there is no HTTP status to report. It still
             # goes through the shared formatter: a provider that writes its own
             # error wording is exactly how the retry contract broke before.
-            return provider_error_from_exception(exc, f"MLX/{model}")
+            raise_provider_error_from_exception(exc, f"MLX/{model}")
 
         finally:
             if temp_jpeg:

--- a/pytest_tests/integration/test_provider_against_failing_server.py
+++ b/pytest_tests/integration/test_provider_against_failing_server.py
@@ -23,7 +23,11 @@ import pytest
 _ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(_ROOT / "imagedescriber"))
 
-from ai_providers import OllamaProvider, _is_retryable_error  # noqa: E402
+from ai_providers import (  # noqa: E402
+    OllamaProvider,
+    ProviderError,
+    _is_retryable_error,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -121,31 +125,37 @@ def test_transient_statuses_are_retried_then_succeed(failing_server, image, stat
     assert failing_server.requests == 3
 
 
-def test_a_permanent_500_run_reports_a_retryable_error(failing_server, image):
-    """When the server never recovers, the last word must still read transient.
+def test_a_permanent_500_run_raises_a_retryable_failure(failing_server, image):
+    """When the server never recovers, the failure must still read transient.
 
     Callers use that to tell "the model refused" from "the service was down",
     which is the difference between re-running the batch and not bothering.
     """
     failing_server.script = [500]
 
-    result = _describe(failing_server, image)
+    with pytest.raises(ProviderError) as caught:
+        _describe(failing_server, image)
 
+    err = caught.value
     assert failing_server.requests == 4, "initial attempt + 3 retries"
-    assert _is_retryable_error(result), result
-    assert "500" in result
+    assert err.status_code == 500
+    assert err.is_retryable, f"kind={err.kind!r}"
+    assert _is_retryable_error(str(err)), str(err)
 
 
 def test_a_401_is_not_retried(failing_server, image):
     """Retrying a rejected key costs the user four round trips per image."""
     failing_server.script = [401]
 
-    result = _describe(failing_server, image)
+    with pytest.raises(ProviderError) as caught:
+        _describe(failing_server, image)
 
+    err = caught.value
     assert failing_server.requests == 1, (
         f"a 401 was retried {failing_server.requests} times"
     )
-    assert not _is_retryable_error(result), result
+    assert err.status_code == 401
+    assert not err.is_retryable, f"kind={err.kind!r}"
 
 
 def test_token_usage_survives_a_retry(failing_server, image):

--- a/pytest_tests/unit/test_provider_contract.py
+++ b/pytest_tests/unit/test_provider_contract.py
@@ -330,9 +330,33 @@ def image(tmp_path, monkeypatch):
 
 
 def _describe(driver, monkeypatch, tmp_path, image_path, outcomes):
+    """Run describe_image, returning its description. Failures propagate."""
     provider, script = driver.build(monkeypatch, tmp_path, outcomes)
     result = provider.describe_image(image_path, "describe this", "test-model")
     return result, script
+
+
+def _describe_expecting_failure(driver, monkeypatch, tmp_path, image_path,
+                                outcomes):
+    """Run describe_image and return the ProviderError it must raise.
+
+    Providers signal failure by raising, not by returning a string. Anything
+    that comes back normally here is a provider that swallowed a failure and
+    handed back something a caller would store as the image's description --
+    the defect in issue #230 -- so that is a test failure, not a pass.
+    """
+    provider, script = driver.build(monkeypatch, tmp_path, outcomes)
+    try:
+        result = provider.describe_image(image_path, "describe this",
+                                         "test-model")
+    except ProviderError as exc:
+        return exc, script
+
+    pytest.fail(
+        f"{type(provider).__name__}.describe_image returned "
+        f"{result!r} instead of raising ProviderError. A caller cannot tell "
+        "that apart from a description."
+    )
 
 
 # ===========================================================================
@@ -388,16 +412,25 @@ def test_drivers_that_skip_http_give_a_reason():
 ])
 def test_http_status_classifies_correctly(driver, status, should_retry,
                                           monkeypatch, tmp_path, image):
-    """The returned string must be classified the way the status implies."""
-    result, _ = _describe(driver, monkeypatch, tmp_path, image,
-                          [("http", status)])
+    """The raised error must classify the way the status implies.
 
-    assert isinstance(result, str) and result, "a provider must return a string"
-    assert _is_retryable_error(result) is should_retry, (
-        f"{_driver_id(driver)} returned {result!r} for HTTP {status}. "
-        f"_is_retryable_error says {not should_retry}, but a {status} is "
-        f"{'transient' if should_retry else 'permanent'}. "
-        "Build the string with format_provider_error() instead of by hand."
+    Retryability is now a field on the exception rather than something
+    inferred from wording, so this checks the field AND the rendered message
+    -- the message is what ends up in logs and in the failure event.
+    """
+    err, _ = _describe_expecting_failure(driver, monkeypatch, tmp_path, image,
+                                         [("http", status)])
+
+    assert err.status_code == status, (
+        f"{_driver_id(driver)} lost the status code: got {err.status_code!r}"
+    )
+    assert err.is_retryable is should_retry, (
+        f"{_driver_id(driver)} classified HTTP {status} as "
+        f"{'retryable' if err.is_retryable else 'permanent'} (kind={err.kind!r}); "
+        f"a {status} is {'transient' if should_retry else 'permanent'}."
+    )
+    assert _is_retryable_error(str(err)) is should_retry, (
+        f"the rendered message disagrees with the exception: {str(err)!r}"
     )
 
 
@@ -423,8 +456,8 @@ def test_five_hundred_then_two_hundred_returns_a_description(
 @pytest.mark.parametrize("driver", HTTP_DRIVERS, ids=_driver_id)
 def test_a_401_is_not_retried(driver, monkeypatch, tmp_path, image):
     """Retrying a bad API key wastes the user's time on every image."""
-    _, script = _describe(driver, monkeypatch, tmp_path, image,
-                          [("http", 401)])
+    _, script = _describe_expecting_failure(driver, monkeypatch, tmp_path,
+                                            image, [("http", 401)])
     assert script.calls == 1, (
         f"{_driver_id(driver)} retried a 401 {script.calls} times"
     )
@@ -433,15 +466,19 @@ def test_a_401_is_not_retried(driver, monkeypatch, tmp_path, image):
 @pytest.mark.parametrize("driver", HTTP_DRIVERS, ids=_driver_id)
 def test_a_persistent_500_gives_up_and_reports_it(
         driver, monkeypatch, tmp_path, image):
-    """Retries are bounded, and the final answer still reads as an error."""
-    result, script = _describe(driver, monkeypatch, tmp_path, image,
-                               [("http", 500)])
+    """Retries are bounded, and the final failure still reads as transient.
+
+    Callers use that to tell "the model refused" from "the service was down",
+    which decides whether re-running the batch is worth anything.
+    """
+    err, script = _describe_expecting_failure(driver, monkeypatch, tmp_path,
+                                              image, [("http", 500)])
     assert script.calls == 4, (
         f"expected initial attempt + 3 retries, saw {script.calls}"
     )
-    assert _is_retryable_error(result), (
+    assert err.is_retryable, (
         f"{_driver_id(driver)} lost the transient marker on the final "
-        f"attempt: {result!r}"
+        f"attempt: kind={err.kind!r}"
     )
 
 
@@ -460,26 +497,28 @@ def test_success_returns_the_description_unchanged(
 
 @pytest.mark.parametrize("driver", DRIVERS, ids=_driver_id)
 def test_timeout_is_treated_as_transient(driver, monkeypatch, tmp_path, image):
-    result, _ = _describe(driver, monkeypatch, tmp_path, image,
-                          [("timeout", None)])
-    assert _is_retryable_error(result), (
-        f"{_driver_id(driver)} reported a timeout as permanent: {result!r}"
+    err, _ = _describe_expecting_failure(driver, monkeypatch, tmp_path, image,
+                                         [("timeout", None)])
+    assert err.is_retryable, (
+        f"{_driver_id(driver)} reported a timeout as permanent: "
+        f"kind={err.kind!r} message={str(err)!r}"
     )
 
 
 @pytest.mark.parametrize("driver", DRIVERS, ids=_driver_id)
-def test_malformed_response_does_not_escape_as_an_exception(
+def test_malformed_response_raises_rather_than_returning_junk(
         driver, monkeypatch, tmp_path, image):
-    """A garbage response must become an error string, not crash the batch.
+    """An unparseable response is a failure and must be raised as one.
 
-    wxPython swallows exceptions in event handlers, so one escaping here shows
-    up to the user as a button that does nothing.
+    This used to assert the opposite -- that a garbage response came back as a
+    string -- which was the bug: workers_wx stored exactly such a string as the
+    image's description. It must still not escape as some *other* exception
+    type, because a caller can only reasonably handle ProviderError.
     """
-    result, _ = _describe(driver, monkeypatch, tmp_path, image,
-                          [("garbage", None)])
-    assert isinstance(result, str) and result, (
-        f"{_driver_id(driver)} returned {result!r} for an unparseable response"
-    )
+    err, _ = _describe_expecting_failure(driver, monkeypatch, tmp_path, image,
+                                         [("garbage", None)])
+    assert str(err), f"{_driver_id(driver)} raised an error with no message"
+    assert err.kind in ErrorKind.ALL, f"unrecognised kind {err.kind!r}"
 
 
 # ===========================================================================
@@ -500,7 +539,12 @@ def test_formatter_output_always_classifies_as_its_kind(kind, status_code):
         provider="Test", kind=kind, status_code=status_code,
         message="something went wrong", timestamp="2026-07-28 12:00:00,000")
 
-    if status_code is not None:
+    if kind == ErrorKind.UNAVAILABLE:
+        # No request was made, so a status code is meaningless and the
+        # formatter ignores it. A provider that is not configured will not
+        # become configured by trying again.
+        expected = False
+    elif status_code is not None:
         expected = kind_for_status(status_code) in RETRYABLE_KINDS
     else:
         expected = kind in RETRYABLE_KINDS
@@ -596,8 +640,11 @@ def test_no_provider_writes_a_status_code_string_by_hand():
     src = (_ROOT / "imagedescriber" / "ai_providers.py").read_text(
         encoding="utf-8")
 
+    # Everything from the status-token helper down to the retry decorator is
+    # the error-formatting layer: the formatter itself, the predicate, and the
+    # two raise helpers, whose docstrings quote the wording they exist to own.
     formatter_start = src.index("def _status_token(")
-    formatter_end = src.index("def provider_error_from_exception(")
+    formatter_end = src.index("def retry_on_api_error(")
     allowed = src[formatter_start:formatter_end]
 
     offenders = []

--- a/pytest_tests/unit/test_retry_contract.py
+++ b/pytest_tests/unit/test_retry_contract.py
@@ -30,6 +30,7 @@ sys.path.insert(0, str(_ROOT / "imagedescriber"))
 
 from ai_providers import (  # noqa: E402
     OllamaProvider,
+    ProviderError,
     _is_retryable_error,
     retry_on_api_error,
 )
@@ -170,11 +171,13 @@ class _FakeResponse:
         return {"response": self.text}
 
 
-def test_ollama_http_500_produces_a_retryable_string(tmp_path, monkeypatch):
+def test_ollama_http_500_is_raised_as_a_retryable_failure(tmp_path, monkeypatch):
     """ollama.com's cloud vision backend returns 500/502 intermittently.
 
-    The string OllamaProvider returns for that MUST be one the decorator
-    retries -- this is the bug that shipped for nine months.
+    This is the bug that shipped for nine months. It used to assert that the
+    RETURNED string was recognised as retryable; providers now raise, so the
+    same guarantee is expressed on the exception -- both its retryable field
+    and the message it renders, since the message is what reaches the log.
     """
     monkeypatch.setattr("ai_providers.time.sleep", lambda _s: None)
     monkeypatch.chdir(tmp_path)  # keep api_errors.log out of the repo
@@ -188,12 +191,18 @@ def test_ollama_http_500_produces_a_retryable_string(tmp_path, monkeypatch):
 
     provider = OllamaProvider()
     # describe_image is wrapped by the decorator, so this exhausts the retries
-    # and hands back the final error string.
-    result = provider.describe_image(str(image), "describe", "gemma4:31b-cloud")
+    # and then raises the final failure.
+    with pytest.raises(ProviderError) as caught:
+        provider.describe_image(str(image), "describe", "gemma4:31b-cloud")
 
-    assert _is_retryable_error(result), (
-        f"Ollama's HTTP-error string is not recognised as retryable: {result!r}. "
-        "Every 5xx would become a hard per-image failure."
+    err = caught.value
+    assert err.status_code == 500
+    assert err.is_retryable, (
+        f"Ollama's 5xx was classified {err.kind!r}, so every 5xx would become "
+        "a hard per-image failure."
+    )
+    assert _is_retryable_error(str(err)), (
+        f"the rendered message is not recognised as retryable: {str(err)!r}"
     )
 
 


### PR DESCRIPTION
The last code item of #230, and the root-cause fix for a design that has now produced two shipped bugs.

## The problem

`describe_image()` returned a `str` either way — a description on success, a formatted error on failure. Success and failure shared a type, so nothing could tell them apart except by reading the English. That cost twice:

- **`retry_on_api_error` had to infer "transient" from wording.** Ollama said `"Error: HTTP 500"` while the decorator matched `"status code: 5"` — every Ollama 5xx was a hard failure for nine months (#228).
- **`workers_wx` checked only that the result was non-empty**, so an error string was stored as the image's description, counted in the "X of Y described" stats and exported to HTML (#230).

Raising removes the class of bug instead of guarding against it: a caller that forgets to handle failure gets a traceback rather than silently recording nonsense, and the retry decorator branches on a field it already understands.

## Changes

- **`ErrorKind.UNAVAILABLE`** — the provider cannot run at all (no API key, SDK missing, wrong OS). Genuinely distinct from `AUTH`: nothing was sent, so there's no status code and no request to blame. Permanently non-retryable.
- **`raise_provider_error` / `raise_provider_error_from_exception`** replace the return-oriented helpers; 11 error returns across five providers converted.
- **Four `except ProviderError: raise` pass-throughs.** Every provider wraps its body in `except Exception`, which would otherwise catch the `ProviderError` the body just raised and re-wrap it — degrading a classified error back to `UNKNOWN` and double-formatting the message. Easy to miss, and it would have quietly undone half the point.

Message wording is unchanged, so logs and saved diagnostics stay comparable.

## Tests assert on fields, not parsed English

`err.is_retryable` and `err.status_code` instead of `_is_retryable_error(some_string)` — which is the refactor's benefit showing up in the tests themselves.

Added `_describe_expecting_failure()`, which fails loudly if a provider *returns* anything for an injected fault. A returned value is precisely the defect.

**One old test was asserting the bug.** `test_malformed_response_does_not_escape_as_an_exception` required that a garbage response came back *as a string* — exactly what `workers_wx` then stored as a description. Inverted.

## A latent bug fixed for free

`tools/test_new_models.py` treated `len(description.strip()) > 10` as "✅ WORKS". Every error string is longer than 10 characters, so a model failing with a 401 was reported as working. It already wraps the call in `try/except`, so the raise routes correctly with no edit.

## Verification

- 941 passed, coverage 24.93%, all 12 floors met.
- `ImageDescriber.exe` rebuilt (`ai_providers.py` is in `hiddenimports`) and confirmed to launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
