### PR TITLE
Make a CLI bundle's folder tree match the GUI's (#230)

### DIFF
--- a/cli/main.py
+++ b/cli/main.py
@@ -490,7 +490,8 @@ def cmd_describe(args):
         _auto_export_workspace(ws, args.quiet)
 
 
-def _extract_one_video_into_workspace(ws, video: Path, opts) -> list:
+def _extract_one_video_into_workspace(ws, video: Path, opts,
+                                      source_root: Path = None) -> list:
     """
     Extract one video's frames into ws.derived_dir("frames")/<stem>/ and register
     the video (reference item) plus each frame (extracted_frame item) in the
@@ -505,13 +506,32 @@ def _extract_one_video_into_workspace(ws, video: Path, opts) -> list:
     result = extract_frames_to_dir(video, frames_dir, opts)
 
     # Register the video as a reference-mode item (no copy — videos are large).
-    video_wi = ws.get_item(video.name)
+    #
+    # subfolder must be set here explicitly. This is the one place an item is
+    # built by hand instead of through add_image(), so it was missed when the
+    # four inline subfolder computations were unified on
+    # source_relative_subfolder() -- and add_source_folder() defaults to
+    # include_videos=False, so nothing else ever assigned one.
+    #
+    # The result was a CLI bundle whose photos grouped under "07" while its
+    # videos carried subfolder=None and hung off the tree root, so the folder
+    # node held only part of the folder. The GUI's own scan
+    # (on_files_discovered) anchors every discovered file including videos, so
+    # the same folder opened as two different shapes depending on which side
+    # created the workspace.
+    from idt_core.workspace import source_relative_subfolder
+
+    video_subfolder = (
+        source_relative_subfolder(video, source_root) if source_root else None
+    )
+    video_wi = ws.get_item(video.name, video_subfolder)
     if video_wi is None:
         video_wi = WorkspaceItem(
             image=video.name,
             source_path=str(video),
             storage="reference",
             item_type="video",
+            subfolder=video_subfolder,
             is_missing=not video.exists(),
         )
         ws.save_item(video_wi)
@@ -555,7 +575,7 @@ def _extract_videos_into_workspace(ws, source: Path, args) -> None:
     _set_console_title(f"IDT - Extracting Video Frames (0 of {len(videos)})")
     for _n, video in enumerate(videos, start=1):
         try:
-            frame_items = _extract_one_video_into_workspace(ws, video, opts)
+            frame_items = _extract_one_video_into_workspace(ws, video, opts, source)
             total_frames += len(frame_items)
             _set_console_title(
                 f"IDT - Extracting Video Frames ({_n} of {len(videos)}, "
@@ -889,7 +909,7 @@ def cmd_video(args):
         if not args.quiet:
             print(f"  Extracting frames: {video.name}")
         try:
-            frame_items = _extract_one_video_into_workspace(ws, video, opts)
+            frame_items = _extract_one_video_into_workspace(ws, video, opts, source)
             all_frame_items.extend(frame_items)
             if not args.quiet:
                 print(f"    {len(frame_items)} frames -> {ws.derived_dir('frames') / video.stem}")

--- a/imagedescriber/imagedescriber_wx.py
+++ b/imagedescriber/imagedescriber_wx.py
@@ -3100,7 +3100,23 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
                 parent_node = folder_nodes[accumulated]
             return folder_nodes[subfolder]
 
-        for subfolder_key, items_in_group in subfolder_groups.items():
+        # Folder nodes first, loose root-level items after -- the convention
+        # every file browser uses, and load-bearing here.
+        #
+        # subfolder_groups is ordered by first appearance in date-sorted
+        # mixed_items, so a workspace whose videos happen to be older than its
+        # photos rendered all of them at the root BEFORE creating the folder
+        # node. In a real 539-item bundle that put the source folder at
+        # position 30 of 30, below 29 videos and off the bottom of the tree.
+        # The node existed and held all 195 images; you simply could not see it
+        # without scrolling past everything else, which reads exactly like the
+        # missing-folder-node bug this was supposed to have fixed.
+        ordered_groups = (
+            [(k, v) for k, v in subfolder_groups.items() if k]
+            + [(k, v) for k, v in subfolder_groups.items() if not k]
+        )
+
+        for subfolder_key, items_in_group in ordered_groups:
             parent_node = _get_or_create_folder_node(subfolder_key) if subfolder_key else root
 
             for file_path, item in items_in_group:

--- a/pytest_tests/unit/test_cli_video_subfolder.py
+++ b/pytest_tests/unit/test_cli_video_subfolder.py
@@ -1,0 +1,151 @@
+"""A video in the source folder belongs to that folder, like the photos beside it.
+
+Reported against a real CLI bundle: the source folder appeared in the tree but
+held only part of itself. 195 photos carried subfolder="07"; the 29 videos in
+the same folder carried None and hung off the tree root instead.
+
+Two things combined to cause it:
+
+  * add_source_folder() defaults to include_videos=False, so it never touched
+    the videos at all -- they are registered separately by the extraction path.
+  * that path is the ONE place a WorkspaceItem is constructed by hand rather
+    than through add_image(), so it was missed when the four inline subfolder
+    computations were unified on source_relative_subfolder().
+
+Nothing assigned a subfolder to a video, and no test noticed because every
+existing fixture contained images only. The GUI's own scan
+(on_files_discovered) anchors every discovered file including videos, so the
+same folder opened as two different shapes depending on which side created the
+workspace.
+
+These tests work on the item the CLI actually registers, without invoking
+opencv or extracting anything.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+if str(_ROOT) not in sys.path:
+    sys.path.insert(0, str(_ROOT))
+
+from idt_core.workspace import (  # noqa: E402
+    Workspace,
+    WorkspaceItem,
+    source_relative_subfolder,
+)
+
+
+@pytest.fixture
+def source(tmp_path):
+    """A source folder holding both photos and a video, as a phone dump does."""
+    root = tmp_path / "Photos" / "2026" / "07"
+    root.mkdir(parents=True)
+    (root / "IMG_0001.jpg").write_bytes(b"\xff\xd8\xff\xe0jpeg")
+    (root / "IMG_0002.jpg").write_bytes(b"\xff\xd8\xff\xe0jpeg")
+    (root / "clip.mov").write_bytes(b"\x00\x00\x00\x18ftypqt  ")
+    return root
+
+
+def _register_video_like_the_cli(ws, video, source_root):
+    """Mirror _extract_one_video_into_workspace's registration step.
+
+    Duplicated rather than imported because the real function also runs opencv
+    frame extraction. The subfolder assignment is what matters here, and
+    test_the_cli_registration_site_passes_a_source_root below pins that the
+    real call site still supplies the argument this depends on.
+    """
+    subfolder = source_relative_subfolder(video, source_root) if source_root else None
+    item = WorkspaceItem(
+        image=video.name,
+        source_path=str(video),
+        storage="reference",
+        item_type="video",
+        subfolder=subfolder,
+        is_missing=False,
+    )
+    ws.save_item(item)
+    return item
+
+
+def test_a_video_gets_the_same_subfolder_as_the_photos_beside_it(tmp_path, source):
+    ws = Workspace.create(tmp_path / "WS")
+    ws.add_source_folder(source, recursive=True)
+
+    photo_subfolders = {i.subfolder for i in ws.items() if i.item_type != "video"}
+    assert photo_subfolders == {"07"}, photo_subfolders
+
+    video = _register_video_like_the_cli(ws, source / "clip.mov", source)
+
+    assert video.subfolder == "07", (
+        f"the video got subfolder={video.subfolder!r} while the photos in the "
+        "same folder got '07'. It will hang off the tree root, so the folder "
+        "node holds only part of the folder."
+    )
+
+
+def test_without_a_source_root_the_video_is_unanchored(tmp_path, source):
+    """Documents the fallback rather than pretending it cannot happen.
+
+    Callers that genuinely have no source folder still get None, which is the
+    old behaviour -- so the guarantee above depends entirely on the source root
+    reaching this code, which the next test checks.
+    """
+    ws = Workspace.create(tmp_path / "WS")
+    video = _register_video_like_the_cli(ws, source / "clip.mov", None)
+    assert video.subfolder is None
+
+
+def test_add_source_folder_still_excludes_videos(tmp_path, source):
+    """Pins the reason the video needs registering separately at all.
+
+    If this ever flips to including videos, the extraction path would register
+    them twice; the assumption is worth failing loudly on rather than drifting.
+    """
+    ws = Workspace.create(tmp_path / "WS")
+    added = ws.add_source_folder(source, recursive=True)
+    assert all(i.item_type != "video" for i in added)
+    assert len(added) == 2, [i.image for i in added]
+
+
+def test_the_cli_registration_site_passes_a_source_root():
+    """The fix is only live if the call sites actually supply the root.
+
+    _extract_one_video_into_workspace takes source_root as an optional
+    argument, so forgetting it at a call site silently restores the bug --
+    every video back to subfolder=None with nothing raised.
+    """
+    src = (_ROOT / "cli" / "main.py").read_text(encoding="utf-8")
+
+    assert "def _extract_one_video_into_workspace(ws, video: Path, opts," in src, (
+        "signature changed; update this test with it"
+    )
+
+    calls = [line.strip() for line in src.splitlines()
+             if "_extract_one_video_into_workspace(ws" in line
+             and not line.strip().startswith("def ")]
+    assert calls, "no call sites found"
+    for call in calls:
+        assert call.rstrip().endswith("opts, source)"), (
+            f"call site does not pass the source root: {call!r}. Without it "
+            "every video reverts to subfolder=None."
+        )
+
+
+def test_the_video_and_its_photos_share_one_tree_group(tmp_path, source):
+    """The user-visible property: one folder node covering the whole folder."""
+    ws = Workspace.create(tmp_path / "WS")
+    ws.add_source_folder(source, recursive=True)
+    _register_video_like_the_cli(ws, source / "clip.mov", source)
+
+    groups = {}
+    for item in ws.items():
+        groups.setdefault(item.subfolder, []).append(item.image)
+
+    assert set(groups) == {"07"}, (
+        f"expected every item under one '07' group, got {sorted(groups)} -- "
+        "anything under None renders at the tree root, outside the folder"
+    )
+    assert len(groups["07"]) == 3

--- a/pytest_tests/unit/test_gui_folder_scope.py
+++ b/pytest_tests/unit/test_gui_folder_scope.py
@@ -304,3 +304,65 @@ def test_selecting_an_image_gives_no_folder_scope(frame, cli_style_bundle):
 
     tree.SelectItem(leaves[0])
     assert frame._selected_folder_scope() is None
+
+
+def test_folder_nodes_render_before_loose_root_items(frame, tmp_path):
+    """Folders first, the way every file browser orders them.
+
+    Not cosmetic. The tree groups by subfolder in first-encountered order over
+    date-sorted items, so a workspace whose ROOT-level items are older than its
+    foldered ones met the root group first and appended every one of them
+    before the folder node was created. In a real 539-item workspace that put
+    the source folder at position 30 of 30, below 29 videos and off the bottom
+    of the list -- indistinguishable, to the person looking at it, from the
+    folder node not existing at all.
+
+    This drives refresh_image_list against a workspace built here rather than
+    loaded from a bundle: add_image caches no date, so a bundle-built fixture
+    sorts every item equal and the ordering never reproduces.
+    """
+    from data_models import ImageWorkspace
+
+    def entry(path, subfolder, iso):
+        return {
+            "file_path": str(path),
+            "item_type": "image",
+            "descriptions": [],
+            "subfolder": subfolder,
+            "parent_video": None,
+            "video_metadata": None,
+            "download_url": None,
+            "download_timestamp": None,
+            "alt_text": None,
+            "exif_datetime": iso,
+            "file_mtime": None,
+            "is_missing": False,
+        }
+
+    items = {}
+    # Root-level items dated EARLIER -- this is the trigger.
+    for n in range(4):
+        pth = tmp_path / f"clip{n}.png"
+        items[str(pth)] = entry(pth, None, f"2001-01-0{n + 1}T10:00:00")
+    # Foldered items dated later.
+    for n in range(2):
+        pth = tmp_path / "07" / f"IMG_000{n}.jpg"
+        items[str(pth)] = entry(pth, "07", f"2016-06-0{n + 1}T10:00:00")
+
+    frame.workspace = ImageWorkspace.from_dict({"items": items})
+    frame.refresh_image_list()
+
+    tree = frame.image_list
+    top = _top_level_nodes(tree)
+    labels = [tree.GetItemText(n) for n in top]
+    folder_positions = [i for i, n in enumerate(top) if tree.GetItemData(n) is None]
+    leaf_positions = [i for i, n in enumerate(top) if tree.GetItemData(n) is not None]
+
+    assert folder_positions, f"no folder node at all; top level is {labels}"
+    assert leaf_positions, (
+        "no loose root-level items were rendered, so this test would pass "
+        f"vacuously; top level is {labels}")
+    assert max(folder_positions) < min(leaf_positions), (
+        "a loose root-level item renders before a folder node. With enough of "
+        "them the folder scrolls out of sight and looks missing entirely. "
+        f"order: {labels}")


### PR DESCRIPTION
Two fixes for the same reported symptom: a CLI-made bundle's source folder not showing up properly in ImageDescriber's tree.

## 1. CLI-registered videos had no subfolder

Your `07.idtw`: 195 photos with `subfolder='07'`, **29 videos with `subfolder=None`**. So the folder node existed but held only part of the folder — the videos hung off the tree root.

Two things combined:

- `add_source_folder()` defaults to `include_videos=False`, so it never touched the videos; they're registered separately by the extraction path.
- That path is **the one place a `WorkspaceItem` is built by hand** instead of through `add_image()`, so it was missed when the four inline subfolder computations were unified on `source_relative_subfolder()`. It's the fifth site, and the only one that doesn't call `add_image`.

No test noticed because every fixture contained images only. The GUI's own scan anchors *every* discovered file including videos, so the same folder opened as two different shapes depending on which side made the workspace.

`_extract_one_video_into_workspace` now takes the source root. Both call sites already had `source` in scope.

## 2. Folder nodes rendered after loose root items

Separately: the folder node was rendered at **position 30 of 30**, below all 29 videos and off the bottom of the tree — indistinguishable from not existing.

`subfolder_groups` is ordered by first appearance in date-sorted items. Videos carry `subfolder=None`, so when they're older than the photos the root group is met first and every one is appended before the folder node is created. Folder nodes now render first, the way every file browser orders them.

Verified against the reported bundle: `07` moves from position 30 of 30 to **position 1**, with all 195 images under it.

## On the tests

Both fixes have tests that fail when the fix is reverted — I checked, because an earlier version of the ordering test passed either way and was therefore worthless.

The ordering test drives `refresh_image_list` against a workspace built in the test rather than loaded from a bundle. Three bundle-based attempts all passed with the fix reverted: `add_image` caches no date, so every item sorted equal; with equal dates the sort is stable and the bundle's own enumeration (foldered items first) decided the order; and setting mtimes with `os.utime` after adding does nothing, since the sort reads `item.file_mtime` cached at add time. A bundle fixture cannot express "root items are older", which is the entire trigger.

The video fix also pins its call sites, since `source_root` is optional and forgetting it would silently restore the bug.

948 passed, coverage 24.95%, all 12 floors met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
