### PR TITLE
ci: point dependabot at main, v4.5 no longer exists

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,6 @@ updates:
   # Root requirements (core CLI/scripts)
   - package-ecosystem: "pip"
     directory: "/"
-    target-branch: "v4.5"
     schedule:
       interval: "weekly"
     labels:
@@ -13,7 +12,6 @@ updates:
   # IDT CLI app
   - package-ecosystem: "pip"
     directory: "/idt"
-    target-branch: "v4.5"
     schedule:
       interval: "weekly"
     labels:
@@ -23,7 +21,6 @@ updates:
   # ImageDescriber GUI app
   - package-ecosystem: "pip"
     directory: "/imagedescriber"
-    target-branch: "v4.5"
     schedule:
       interval: "weekly"
     labels:
@@ -33,7 +30,6 @@ updates:
   # show_metadata tool
   - package-ecosystem: "pip"
     directory: "/tools/show_metadata"
-    target-branch: "v4.5"
     schedule:
       interval: "weekly"
     labels:
@@ -43,7 +39,6 @@ updates:
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "v4.5"
     schedule:
       interval: "weekly"
     labels:


### PR DESCRIPTION
Every entry in `.github/dependabot.yml` carries `target-branch: "v4.5"`. That branch has been merged and deleted, so dependabot is opening PRs against a ref that does not exist — and failing silently.

Evidence it is actually dead, not just quiet:

- Last dependabot PR was #222 on **2026-07-21**. The schedule is weekly, so two cycles have passed with nothing.
- `git ls-remote --heads` returns **no** ref for `v4.5`.
- `GET /repos/.../branches/v4.5` returns **200** — GitHub redirects a deleted branch to the default branch, so the branch looks present unless you check `ls-remote`. That is why this went unnoticed.

Removing the key lets each of the five entries default to the repo default branch, `main`.

Expect a burst of catch-up PRs once this merges — the backlog has been accumulating since 21 July.

🤖 Generated with [Claude Code](https://claude.com/claude-code)