### PR TITLE
Add in-app update checking for Windows and macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,23 +38,44 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Tag must match VERSION
+      # All four must agree. idt_core.__version__ matters most: it is what the
+      # in-app update checker compares against the newest release tag, so drift
+      # there makes an installed copy misreport its own version forever.
+      - name: Tag must match every version source
         shell: bash
         run: |
           set -euo pipefail
           TAG="${GITHUB_REF_NAME}"
           TAG_VERSION="${TAG#v}"
           FILE_VERSION="$(tr -d ' \r\n' < VERSION)"
+          CORE_VERSION="$(sed -n 's/^__version__ = "\(.*\)"$/\1/p' idt_core/__init__.py)"
+          PYPROJECT_VERSION="$(sed -n 's/^version = "\(.*\)"$/\1/p' pyproject.toml | head -1)"
 
-          echo "tag         : $TAG"
-          echo "tag version : $TAG_VERSION"
-          echo "VERSION file: $FILE_VERSION"
+          echo "tag                : $TAG"
+          echo "tag version        : $TAG_VERSION"
+          echo "VERSION file       : $FILE_VERSION"
+          echo "idt_core.__version__: $CORE_VERSION"
+          echo "pyproject.toml     : $PYPROJECT_VERSION"
 
-          if [ "$TAG_VERSION" != "$FILE_VERSION" ]; then
+          fail=0
+          for pair in "VERSION:$FILE_VERSION" \
+                      "idt_core/__init__.py:$CORE_VERSION" \
+                      "pyproject.toml:$PYPROJECT_VERSION"; do
+            name="${pair%%:*}"
+            value="${pair#*:}"
+            if [ -z "$value" ]; then
+              echo "ERROR: could not read a version from $name."
+              fail=1
+            elif [ "$value" != "$TAG_VERSION" ]; then
+              echo "ERROR: $name says '$value' but the tag says '$TAG_VERSION'."
+              fail=1
+            fi
+          done
+
+          if [ "$fail" != "0" ]; then
             echo ""
-            echo "ERROR: tag '$TAG' does not match the VERSION file ('$FILE_VERSION')."
-            echo "A mismatch ships binaries that misreport their own version."
-            echo "Either update VERSION and re-tag, or delete and recreate the tag."
+            echo "A mismatch ships binaries that misreport their own version, which"
+            echo "breaks the in-app update check. Sync all three files and re-tag."
             exit 1
           fi
           echo "OK"

--- a/BuildAndRelease/WinBuilds/installer.iss
+++ b/BuildAndRelease/WinBuilds/installer.iss
@@ -38,6 +38,12 @@ UninstallDisplayName={#MyAppName}
 ChangesEnvironment=yes
 ; Preserve user data during updates
 DirExistsWarning=no
+; In-app updates (Help > Check for Updates) run this installer over a live
+; install. ImageDescriber closes itself first, but an idt.exe console may still
+; be open, so let Setup close what is holding the executables rather than
+; failing on a locked file. No auto-restart: the user relaunches when ready.
+CloseApplications=yes
+RestartApplications=no
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/cli/main.py
+++ b/cli/main.py
@@ -16,6 +16,7 @@ Usage:
   idt models   [--provider NAME]
   idt prompts
   idt config   [--set key=value]
+  idt update
   idt --help
 
 Run "idt <command> --help" for command-specific options.
@@ -1840,6 +1841,40 @@ def cmd_version(args):
     print(f"Python {sys.version.split()[0]}")
     if getattr(sys, "frozen", False):
         print(f"Binary: {sys.executable}")
+    # Deliberately no update check here: `idt version` should be instant and work
+    # offline. Use `idt update` to check.
+
+
+def cmd_update(args):
+    """Report whether a newer release exists. Notify-only by design.
+
+    Downloading and running the installer is the GUI's job (Help > Check for
+    Updates); the installer updates idt and ImageDescriber together, so there is
+    no separate CLI-only download to offer.
+    """
+    from idt_core import updater
+
+    installed = updater.current_version()
+    if not installed:
+        print("Couldn't determine the installed version, so there is nothing to compare.")
+        print(f"Releases: {updater.RELEASES_PAGE}")
+        return
+    print(f"Installed: idt {installed}")
+    try:
+        info = updater.check_for_update()
+    except Exception as exc:
+        print(f"Couldn't check for updates: {exc}")
+        print(f"Releases: {updater.RELEASES_PAGE}")
+        return
+
+    if info is None:
+        print("You are up to date.")
+        return
+
+    print(f"Available: idt {info['version']}")
+    print("")
+    print(f"Download:  {info.get('url') or info.get('page_url') or updater.RELEASES_PAGE}")
+    print("Installing it updates both idt and ImageDescriber.")
 
 
 # ------------------------------------------------------------------ #
@@ -1883,6 +1918,7 @@ Examples:
   idt stats ~/Pictures/ --all                           # across entire photo library
   idt config --set default_provider=anthropic
   idt config --set default_model=claude-opus-4-6
+  idt update                                            # is a newer release out?
 
 Supported providers:
   anthropic  Claude (requires ANTHROPIC_API_KEY)
@@ -2202,6 +2238,16 @@ Supported providers:
 
     p_version = sub.add_parser("version", help="Print version information")
     p_version.set_defaults(func=cmd_version)
+
+    p_update = sub.add_parser(
+        "update",
+        help="Check whether a newer release is available",
+        description=(
+            "Checks GitHub for a newer release and prints where to get it. "
+            "The installer updates both idt and ImageDescriber."
+        ),
+    )
+    p_update.set_defaults(func=cmd_update)
 
     return parser
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -151,10 +151,42 @@ IDT uses environment variables for API keys so they are never stored in your wor
 
 ### Updating IDT
 
-**Pre-built executables**
+**Let IDT tell you (easiest)**
 
-1. Download the latest `idt.exe` and `ImageDescriber.exe` (or `ImageDescriber.app` on macOS) from the [releases page](https://github.com/kellylford/Image-Description-Toolkit/releases).
-2. Replace the old executables in your folder (or `/Applications` on macOS).
+IDT checks for updates itself. Once a day at most, shortly after ImageDescriber
+starts, it quietly asks GitHub whether a newer version exists. If there is nothing
+new it says nothing; it only speaks up when there is an update. You can also ask at
+any moment with **Help → Check for Updates...**, and turn the automatic check off
+with **Help → Automatically Check for Updates** (the manual check still works when
+it's off).
+
+When an update is found you get three choices:
+
+| Choice | What happens |
+|---|---|
+| Download | Fetches the new version (see below) |
+| Skip This Version | You are never asked about that particular version again |
+| Later | Ask again tomorrow |
+
+- **Windows:** Download fetches the installer, closes ImageDescriber, and runs it.
+  Windows asks for administrator permission, because IDT installs to the root of
+  your system drive.
+- **macOS:** Download saves the disk image to your Downloads folder and shows it in
+  Finder. Quit ImageDescriber, then drag the new ImageDescriber to Applications.
+
+**One update covers both tools.** The Windows installer and the macOS disk image each
+contain `idt` *and* ImageDescriber, so updating from either one updates both.
+
+From the command line, `idt update` reports your installed version, whether a newer
+one exists, and where to get it. It does not install anything itself.
+
+The check reads the public GitHub releases list and nothing else — no account, no
+telemetry, no data sent.
+
+**Installing an update by hand**
+
+1. Download the latest installer (Windows) or disk image (macOS) from the [releases page](https://github.com/kellylford/Image-Description-Toolkit/releases).
+2. Run the installer, or drag the new `ImageDescriber.app` to `/Applications`. If you use the standalone executables instead, replace the old `idt.exe` and `ImageDescriber.exe` in your folder.
 3. Your existing `.idtw` workspace bundles and `~/.idt/config.json` settings are preserved — no migration needed.
 
 **From source**
@@ -628,7 +660,31 @@ Configuration is stored in `~/.idt/config.json`.
 idt version
 ```
 
-Prints the application version, Python version, and executable path.
+Prints the application version, Python version, and executable path. Never touches
+the network — use `idt update` to check for a newer release.
+
+#### idt update — Check for a Newer Release
+
+```
+idt update
+```
+
+Asks GitHub whether a newer release exists and prints where to get it:
+
+```
+Installed: idt 4.5.0
+Available: idt 4.5.1
+
+Download:  https://github.com/kellylford/Image-Description-Toolkit/releases/download/v4.5.1/ImageDescriptionToolkitSetup-4.5.1-windows.exe
+Installing it updates both idt and ImageDescriber.
+```
+
+This command is notify-only — it downloads and installs nothing. Run the installer
+yourself, or use ImageDescriber's **Help → Check for Updates...**, which can download
+and launch it for you. Either way, one installer updates both tools.
+
+If the check fails (no internet, GitHub unreachable) it says so rather than claiming
+you are up to date.
 
 ---
 
@@ -804,6 +860,8 @@ The application has two modes:
 |---|---|
 | User Guide... | Open this guide |
 | Report an Issue... | Go to the GitHub issue tracker |
+| Check for Updates... | Ask GitHub right now whether a newer version exists |
+| Automatically Check for Updates | Toggle the once-a-day check at startup (on by default) |
 | About | Show version information |
 
 ---

--- a/docs/WorkTracking/2026-08-10-session-summary.md
+++ b/docs/WorkTracking/2026-08-10-session-summary.md
@@ -1,0 +1,103 @@
+# 2026-08-10 — In-app update checking (Windows + macOS)
+
+## Goal
+
+Let an installed copy of IDT learn that a newer release exists, before cutting
+v4.5. Previously the only way to find out was to revisit the GitHub releases page.
+
+## Approach and why
+
+Four sibling repos already solve this two ways: Velopack silent self-update
+(QuickMail, GHManage) and a GitHub Releases API checker that downloads and runs
+the installer (Scores, FastWeather).
+
+**Chose the Scores-style checker.** Velopack would mean replacing Inno Setup,
+relocating the install from `C:\idt` to `%LocalAppData%`, and reimplementing the
+installer's `IDT_CONFIG_DIR` registry write, PATH addition, and optional winget
+Ollama install — plus a migration for existing 4.x installs. Not realistic before
+4.5. Velopack is filed for 5.0.
+
+## Files changed
+
+| File | Change |
+|---|---|
+| `idt_core/updater.py` | **New.** Releases-API check, per-platform asset match, SHA256-verified streamed download, URL allowlist. |
+| `idt_core/config.py` | `UserConfig`: `auto_check_updates`, `skipped_update_version`, `last_update_check`. |
+| `imagedescriber/imagedescriber_wx.py` | Help menu items; manual + silent checks; update dialog; timer-driven download progress. |
+| `cli/main.py` | `idt update` (notify-only); docstring + epilog. |
+| `imagedescriber/imagedescriber_wx.spec` | `idt_core.updater` hiddenimport; fixed `.app` version regex. |
+| `idt/idt.spec` | `idt_core.updater` hiddenimport. |
+| `BuildAndRelease/WinBuilds/installer.iss` | `CloseApplications=yes`, `RestartApplications=no`. |
+| `.github/workflows/release.yml` | Validate gate now checks all three version sources, not just `VERSION`. |
+| `pytest_tests/test_updater.py` | **New.** 61 tests. |
+| `docs/release-notes-v4.5.0.md`, `docs/USER_GUIDE.md`, `docs/packaging/DISTRIBUTION_CHECKLIST.md` | Documentation. |
+
+## Decisions
+
+- **Version source is `idt_core.__version__`, not `shared/wx_common.get_app_version()`.**
+  The latter hunts for the `VERSION` file and falls back to `"1.0.0"`, which would
+  tell users they are three major versions behind. Because the updater now depends
+  on it, `release.yml` gained a gate asserting `VERSION`, `idt_core/__init__.py`,
+  and `pyproject.toml` all match the tag.
+- **`current_version()` returns `None` on failure, not a low sentinel.** A `"0.0.0"`
+  fallback would make every release look newer — nagging forever. Unknown version
+  suppresses the check.
+- **Tag parsing is strictly numeric** (`v4.5.0`, not `v4beta2` / `v4.0.0Beta3`).
+  A digit-after-`v` guard let this repo's own historical tags parse as releases.
+  Caught by a test, not by review.
+- **Notify-only CLI.** One installer updates both tools, so a CLI-only download
+  path would be redundant.
+- **macOS stops at "here is the DMG."** A DMG cannot install over a running app.
+  Filed as a follow-up.
+
+## Review findings fixed
+
+An independent review found five defects, all fixed:
+
+1. **Progress dialog `Destroy()` could nest inside `Update()`** — `wx.ProgressDialog.Update()`
+   yields for UI events, so a `wx.CallAfter` completion callback could be dispatched
+   from inside it and free the dialog mid-call. Replaced per-chunk `CallAfter` with
+   worker-written counters polled by a `wx.Timer`, plus a re-entrancy guard.
+2. **Silent installer-launch failure** — added a pre-flight existence check and a
+   parentless `wx.MessageBox` fallback (the frame is already closing by then).
+3. **`"0.0.0"` version fallback** — see above.
+4. **No integrity check on a downloaded executable** — now verified against the
+   release's `SHA256SUMS.txt`; HTTPS + GitHub-host allowlist on download URLs;
+   response closed via `with`; partial file removed on any failure; split
+   `(connect, read)` timeouts so a stalled server cannot freeze the modal dialog.
+5. **Help menu accelerator collisions** (`&U` with User Guide, `&A` with About) —
+   now `Up&dates` and `Chec&k`.
+
+## Testing
+
+**Done:**
+- `pytest pytest_tests/` — 1011 passed, 14 skipped.
+- 61 updater unit tests: version compare, tag parsing, asset selection per platform,
+  draft/prerelease skipping, highest-not-first, network failure propagation,
+  URL allowlist, checksum parse/mismatch, cancel and mid-stream-failure cleanup.
+- GUI handler harness (real methods on a shown frame, stubbed modals): 7/7 —
+  update found, skip persists, silent check honours skip, up-to-date, unreachable
+  feed reports honestly, preference round-trip.
+- Frozen mode: rebuilt both exes; `idt.exe version` and `idt.exe update` work
+  against live GitHub and a `file://` fixture feed, confirming the hiddenimport.
+- `installer.iss` compiles with the new directives.
+- `release.yml` gate simulated: passes when synced, fails on mismatch, survives a
+  no-match `sed` under `set -euo pipefail`.
+
+**NOT tested:**
+- **The real download-and-install path.** No release newer than 4.5.0 exists yet,
+  so nothing has actually been downloaded from GitHub and executed. Verified only
+  up to the point where Setup takes over.
+- **Everything macOS.** Built and tested on Windows only. The DMG, the Finder
+  reveal, and the `.app` `CFBundleShortVersionString` fix are unverified on a Mac.
+- **The `Update()`/`Destroy()` crash was never reproduced naturally** — not by the
+  reviewer in 22 attempts, nor by 25 rounds against the old code here. The
+  mechanism was proven under forced conditions; the fix removes it structurally
+  rather than fixing an observed field crash.
+- Installer replace-in-place over a running copy.
+
+## Follow-ups filed
+
+1. Evaluate Velopack for 5.0 (silent background self-update).
+2. macOS update experience — signed `.pkg` or in-place `.app` replacement.
+3. README download names do not match the assets CI publishes.

--- a/docs/packaging/DISTRIBUTION_CHECKLIST.md
+++ b/docs/packaging/DISTRIBUTION_CHECKLIST.md
@@ -221,7 +221,9 @@ ImageDescriber_v2.0_AMD64.zip
 - [ ] Automated testing script
 - [ ] Version number in app title bar
 - [ ] First-run wizard in the app itself
-- [ ] Auto-update checker (optional)
+- [x] Auto-update checker — shipped in v4.5 (`idt_core/updater.py`; ImageDescriber
+      Help menu, `idt update`). Notify-and-download; silent self-update via Velopack
+      is the next step.
 - [ ] Telemetry for error reporting (opt-in)
 
 ---

--- a/docs/release-notes-v4.5.0.md
+++ b/docs/release-notes-v4.5.0.md
@@ -105,6 +105,8 @@ engine made them easy:
 | `download` | Fetch images from a web page (`--describe` to describe them). |
 | `video` | Extract frames and optionally describe them. |
 | `models` / `prompts` / `guide` | Check models / list prompts / interactive wizard. |
+| `version` | Print the installed version, Python version, and binary path. |
+| `update` | **New** — check whether a newer release is available. |
 
 ---
 
@@ -139,6 +141,49 @@ which noticeably improves descriptions.
 
 ---
 
+## IDT Now Tells You When There's an Update
+
+Until now the only way to learn about a new version was to go back to the GitHub
+releases page and look. v4.5 adds an update check to both tools.
+
+**ImageDescriber** gains two items in the **Help** menu:
+
+- **Check for Updates...** — asks right now, and tells you either that you're up to
+  date or that a newer version exists.
+- **Automatically Check for Updates** — on by default. Once a day at most, shortly
+  after launch, IDT quietly checks. If there's nothing new it says nothing at all;
+  it only speaks up when there's an update.
+
+When an update is found you get three choices: **Download**, **Skip This Version**
+(never asked about that particular version again), or **Later**.
+
+**Windows:** choosing Download fetches the installer, closes ImageDescriber, and
+runs it. Windows will ask for administrator permission, because IDT installs to the
+root of your system drive. Your settings, workspaces, and descriptions are left
+alone.
+
+**macOS:** choosing Download saves the disk image to your Downloads folder and shows
+it in Finder. Quit ImageDescriber, then drag the new ImageDescriber to Applications.
+(Making this as automatic as Windows is on the list.)
+
+**Command line:**
+
+```
+idt update
+```
+
+reports your installed version, whether a newer one exists, and where to get it.
+
+**One update covers both tools.** The Windows installer and the macOS disk image each
+contain `idt` *and* ImageDescriber, so updating from either one updates both. You
+never have to update them separately.
+
+The check reads the public GitHub releases list and nothing else — no account, no
+telemetry, no data sent. Turn it off any time with the Help menu item; **Check for
+Updates** still works on demand when it's off.
+
+---
+
 ## Bug Fixes
 
 - **UTF-8 BOM in stdin mode on Windows.** Reading image paths from stdin in PowerShell
@@ -161,7 +206,9 @@ which noticeably improves descriptions.
   Viewer.
 - **`idt guide` needs an interactive terminal.** If it hangs in a non-interactive
   environment, press Ctrl+C and use `idt describe` directly.
-- **No `idt version` command.** Use `idt --help`. (The old CLI had `idt version`.)
+- **`idt update` is notify-only.** It tells you a new version exists and where to get
+  it, but does not download or install anything. Use the installer (or
+  ImageDescriber's Help > Check for Updates) to actually update.
 - **No automated tests yet for the CLI command layer** (`cli/main.py`). The engine,
   the workspace bundle, the describe pipeline, and the GUI⇄bundle bridge are unit
   tested; the thin CLI argument layer is exercised manually.

--- a/idt/idt.spec
+++ b/idt/idt.spec
@@ -80,6 +80,7 @@ a = Analysis(
 
         # ---- idt_core new modules ----
         'idt_core.config_loader',
+        'idt_core.updater',
         'idt_core.gallery_exporter',
 
         # ---- jaraco (required by pkg_resources / setuptools >= 75) ----

--- a/idt_core/config.py
+++ b/idt_core/config.py
@@ -83,6 +83,15 @@ class UserConfig:
     # a downloaded image's HTML alt text as its own description (model "Website Alt
     # Text"), in addition to any AI-generated one. Default on.
     preserve_alt_text: bool = True
+    # Whether ImageDescriber checks GitHub for a newer release at startup. The
+    # manual Help > Check for Updates always runs regardless. See idt_core/updater.py.
+    auto_check_updates: bool = True
+    # A version the user chose "Skip This Version" on; the startup check never
+    # offers that exact version again. Manual checks ignore it.
+    skipped_update_version: Optional[str] = None
+    # ISO timestamp of the last startup check, used to throttle to once a day so
+    # every launch does not hit the GitHub API.
+    last_update_check: Optional[str] = None
 
     def workspace_root_path(self) -> Path:
         """Resolved workspace root. Defaults to ~/Documents/idt."""
@@ -99,12 +108,14 @@ class UserConfig:
         except Exception:
             return cls()
         obj = cls()
-        for key in ("default_provider", "default_model", "default_prompt_name", "workspace_root"):
+        for key in ("default_provider", "default_model", "default_prompt_name", "workspace_root",
+                    "skipped_update_version", "last_update_check"):
             if key in data:
                 setattr(obj, key, data[key])
         obj.custom_prompts = data.get("custom_prompts", {})
         obj.copy_originals = bool(data.get("copy_originals", False))
         obj.preserve_alt_text = bool(data.get("preserve_alt_text", True))
+        obj.auto_check_updates = bool(data.get("auto_check_updates", True))
         return obj
 
     def save(self) -> None:
@@ -116,9 +127,14 @@ class UserConfig:
             "custom_prompts": self.custom_prompts,
             "copy_originals": self.copy_originals,
             "preserve_alt_text": self.preserve_alt_text,
+            "auto_check_updates": self.auto_check_updates,
         }
         if self.workspace_root:
             data["workspace_root"] = self.workspace_root
+        if self.skipped_update_version:
+            data["skipped_update_version"] = self.skipped_update_version
+        if self.last_update_check:
+            data["last_update_check"] = self.last_update_check
         _CONFIG_FILE.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
 
     def get_prompt_text(self, name: str) -> Optional[str]:

--- a/idt_core/updater.py
+++ b/idt_core/updater.py
@@ -1,0 +1,323 @@
+"""In-app update check via the GitHub Releases API.
+
+Reads the repository's releases, compares the newest ``v<semver>`` tag to the
+running version and — when newer — hands the caller the download URL for this
+platform's installer asset.
+
+One update covers everything. Both the Windows installer and the macOS DMG carry
+``idt`` and ``ImageDescriber`` together, so a user who updates from either app
+gets both. Callers must say so in their user-facing text.
+
+Platform behaviour differs on purpose:
+
+* Windows — download ``ImageDescriptionToolkitSetup-<v>-windows.exe`` to temp and
+  launch it. The caller exits immediately so Setup can replace the running
+  executables.
+* macOS — download ``IDT-<v>-macos-arm64.dmg`` to ~/Downloads and reveal it in
+  Finder. A DMG cannot install itself over a running app, so the last step stays
+  manual for now (see the macOS update-experience issue).
+
+Only meaningful for a frozen (PyInstaller) build; running from source there is
+nothing for an installer to replace, so callers gate the automatic check on
+``is_frozen()``. A manual check still works from source and reports honestly by
+sending the user to the releases page.
+
+Set ``IDT_UPDATE_FEED`` to a URL (or a ``file://`` URL of a JSON fixture shaped
+like the GitHub releases array) to test the flow without publishing a release.
+"""
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import url2pathname
+
+import requests
+
+GITHUB_REPO = "kellylford/Image-Description-Toolkit"
+DEFAULT_RELEASES_URL = f"https://api.github.com/repos/{GITHUB_REPO}/releases?per_page=30"
+RELEASES_PAGE = f"https://github.com/{GITHUB_REPO}/releases/latest"
+
+# Releases are tagged v<semver> (e.g. v4.5.0).
+TAG_PREFIX = "v"
+
+
+
+def current_version():
+    """The running version, or None if it cannot be determined.
+
+    Deliberately ``idt_core.__version__`` and not ``shared.wx_common.get_app_version()``:
+    the latter hunts for the VERSION file on disk and falls back to "1.0.0" when
+    it cannot find it, which would tell the user they are three major versions
+    behind. ``__version__`` is compiled into both frozen binaries.
+
+    Returns None rather than a low sentinel on failure. A sentinel like "0.0.0"
+    would make every release look newer, so a user whose version lookup broke
+    would be nagged to reinstall on every single launch, forever. Not knowing our
+    own version is a reason to stay quiet, not a reason to always fire.
+    """
+    try:
+        from idt_core import __version__
+        return __version__ or None
+    except Exception:
+        return None
+
+
+def _headers() -> dict:
+    return {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": f"IDT/{current_version() or 'unknown'}",
+    }
+
+
+def releases_url() -> str:
+    """The feed to read. IDT_UPDATE_FEED overrides it for testing."""
+    return os.environ.get("IDT_UPDATE_FEED") or DEFAULT_RELEASES_URL
+
+
+def is_frozen() -> bool:
+    """True when running from the PyInstaller build rather than from source."""
+    return getattr(sys, "frozen", False)
+
+
+def _version_tuple(v):
+    return tuple(int(x) for x in re.findall(r"\d+", v or "")) or (0,)
+
+
+def is_newer(latest, current) -> bool:
+    """True if `latest` is a higher version than `current`."""
+    a, b = _version_tuple(latest), _version_tuple(current)
+    n = max(len(a), len(b))
+    a += (0,) * (n - len(a))  # zero-pad so 4.5 and 4.5.0 compare equal
+    b += (0,) * (n - len(b))
+    return a > b
+
+
+def _release_version(tag):
+    """Return the version from a `v<numeric semver>` tag, else None.
+
+    The remainder must be purely numeric dotted digits. Merely requiring a digit
+    after the `v` is not enough here: this repo's history contains `v4beta2` and
+    `v4.0.0Beta3`, which would otherwise parse as releases 4.2 and 4.0.0.3. A
+    stable-channel checker should not offer a beta at all.
+    """
+    if tag and tag.startswith(TAG_PREFIX):
+        rest = tag[len(TAG_PREFIX):]
+        if re.fullmatch(r"\d+(?:\.\d+)*", rest):
+            return rest
+    return None
+
+
+def _asset_url(release, predicate):
+    for asset in release.get("assets") or []:
+        name = (asset.get("name") or "").lower()
+        if predicate(name):
+            return asset.get("browser_download_url")
+    return None
+
+
+def checksums_for(release):
+    """URL of the release's SHA256SUMS.txt, or None (see release.yml)."""
+    return _asset_url(release, lambda n: n == "sha256sums.txt")
+
+
+def asset_for_platform(release):
+    """URL of this platform's installer asset in `release`, or None.
+
+    Returning None matters: it lets the caller fall back to opening the releases
+    page rather than offering a Windows user a .dmg. Matching is by shape rather
+    than exact name so a locally built `ImageDescriptionToolkitSetup_4.5.0.exe`
+    is recognised alongside CI's `ImageDescriptionToolkitSetup-4.5.0-windows.exe`.
+    """
+    for asset in release.get("assets") or []:
+        name = (asset.get("name") or "").lower()
+        if sys.platform == "darwin":
+            if name.startswith("idt-") and name.endswith(".dmg"):
+                return asset.get("browser_download_url")
+        elif sys.platform.startswith("win"):
+            if name.startswith("imagedescriptiontoolkitsetup") and name.endswith(".exe"):
+                return asset.get("browser_download_url")
+    return None
+
+
+def _fetch_releases():
+    """The releases array. Reads a file:// URL directly so a local fixture works."""
+    url = releases_url()
+    if url.startswith("file://"):
+        path = url2pathname(urlparse(url).path)
+        return json.loads(Path(path).read_text(encoding="utf-8")) or []
+    resp = requests.get(url, headers=_headers(), timeout=15)
+    resp.raise_for_status()
+    return resp.json() or []
+
+
+def check_for_update(current=None):
+    """Return details of the newest release if it is newer than the running one.
+
+    Returns ``{'version', 'url', 'notes', 'page_url'}`` — where ``url`` is None
+    when the release has no asset for this platform — or None when already up to
+    date.
+
+    Raises on network/API failure so a manual check can report "couldn't check"
+    rather than silently claiming the app is up to date.
+    """
+    current = current or current_version()
+    if not current:
+        # We do not know what we are running; anything we said would be a guess.
+        return None
+    releases = _fetch_releases()
+
+    best, best_ver = None, None
+    for r in releases:
+        if r.get("draft") or r.get("prerelease"):
+            continue
+        ver = _release_version(r.get("tag_name") or "")
+        if not ver:
+            continue
+        if best is None or _version_tuple(ver) > _version_tuple(best_ver):
+            best, best_ver = r, ver
+
+    if best is None or not is_newer(best_ver, current):
+        return None
+
+    return {
+        "version": best_ver,
+        "url": asset_for_platform(best),
+        "checksums_url": checksums_for(best),
+        "notes": best.get("body") or "",
+        "page_url": best.get("html_url") or RELEASES_PAGE,
+    }
+
+
+def download_dir() -> Path:
+    """Where the downloaded asset lands.
+
+    Windows puts the installer in temp — it runs once and is never seen again.
+    macOS puts the DMG in ~/Downloads, because the user has to open it by hand.
+    """
+    if sys.platform == "darwin":
+        target = Path.home() / "Downloads"
+        if target.is_dir():
+            return target
+    return Path(tempfile.gettempdir())
+
+
+def _validate_download_url(url):
+    """Refuse to download anything that is not an HTTPS GitHub release asset.
+
+    We hand the result to os.startfile, so this is the one place to be strict.
+    IDT_UPDATE_FEED lets a feed be redirected for testing; without this check
+    that would also be a way to make IDT fetch and run an arbitrary binary.
+    """
+    parts = urlparse(url or "")
+    host = (parts.hostname or "").lower()
+    if parts.scheme != "https" or not (
+        host == "github.com" or host.endswith(".github.com")
+        or host.endswith(".githubusercontent.com")
+    ):
+        raise ValueError(f"Refusing to download update from untrusted URL: {url}")
+    return url
+
+
+def expected_sha256(checksums_url, filename):
+    """Look up `filename` in a SHA256SUMS.txt, or None if absent/unreadable."""
+    if not checksums_url:
+        return None
+    try:
+        resp = requests.get(_validate_download_url(checksums_url),
+                            headers=_headers(), timeout=(10, 30))
+        resp.raise_for_status()
+        for line in resp.text.splitlines():
+            parts = line.split()
+            # "<hex>  <name>" — the name may carry a leading * for binary mode.
+            if len(parts) >= 2 and parts[-1].lstrip("*") == filename:
+                return parts[0].lower()
+    except Exception:
+        return None
+    return None
+
+
+def download_asset(url, progress=None, should_cancel=None, checksums_url=None):
+    """Download `url` and return the local path, or None if cancelled.
+
+    ``progress`` (optional) is called with (downloaded_bytes, total_bytes); total
+    is 0 when the server sends no Content-Length, which callers should render as
+    an indeterminate bar rather than a percentage that lies.
+    ``should_cancel`` (optional) is polled between chunks; when it returns True
+    the partial file is deleted and None is returned.
+    ``checksums_url`` (optional) points at the release's SHA256SUMS.txt; when the
+    file is listed there the download must match or a ValueError is raised and
+    the file is deleted. We are about to execute this thing.
+
+    Any failure removes the partial file rather than leaving a half-downloaded
+    installer sitting in temp for someone to run later.
+    """
+    _validate_download_url(url)
+    name = os.path.basename(urlparse(url).path) or "IDT-Update"
+    path = download_dir() / name
+    digest = hashlib.sha256()
+    done = 0
+    try:
+        # (connect, read) — a stalled server must not hold the UI for minutes.
+        with requests.get(url, stream=True, timeout=(15, 60)) as resp:
+            resp.raise_for_status()
+            total = int(resp.headers.get("Content-Length") or 0)
+            with open(path, "wb") as f:
+                for chunk in resp.iter_content(chunk_size=65536):
+                    if should_cancel and should_cancel():
+                        raise _Cancelled()
+                    if chunk:
+                        f.write(chunk)
+                        digest.update(chunk)
+                        done += len(chunk)
+                        if progress:
+                            progress(done, total)
+
+        want = expected_sha256(checksums_url, name)
+        if want and digest.hexdigest().lower() != want:
+            raise ValueError(
+                f"Downloaded {name} does not match the published checksum. "
+                "The file was discarded; try again, or download it from the "
+                "releases page."
+            )
+    except _Cancelled:
+        _remove_quietly(path)
+        return None
+    except BaseException:
+        _remove_quietly(path)
+        raise
+    return str(path)
+
+
+class _Cancelled(Exception):
+    """Internal: the user aborted the download."""
+
+
+def _remove_quietly(path):
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+def launch_installer(path) -> bool:
+    """Hand the downloaded file off to the OS.
+
+    Windows starts the installer. The caller must ALREADY have closed the app —
+    Setup replaces the running executables, and starting it while a save prompt
+    is still on screen leaves the two racing. macOS reveals the DMG in Finder and
+    the app keeps running; mounting and copying over a running .app is the
+    user's move.
+
+    Returns True on the platforms where an installer was actually started.
+    """
+    if sys.platform == "darwin":
+        subprocess.run(["open", "-R", str(path)], check=False)
+        return False
+    os.startfile(str(path))  # noqa: S606 - a file this process just downloaded
+    return True

--- a/idt_core/updater.py
+++ b/idt_core/updater.py
@@ -302,6 +302,8 @@ def _remove_quietly(path):
     try:
         os.remove(path)
     except OSError:
+        # Already gone, or locked by a scanner. This only ever runs on a path we
+        # are abandoning anyway, so a leftover temp file is not worth surfacing.
         pass
 
 

--- a/imagedescriber/imagedescriber_wx.py
+++ b/imagedescriber/imagedescriber_wx.py
@@ -8549,6 +8549,8 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
                     if (datetime.now() - last).total_seconds() < 24 * 3600:
                         return
                 except ValueError:
+                    # Corrupt or hand-edited timestamp. Treat it as "never
+                    # checked" and let the check run; it rewrites the value.
                     pass
 
             cfg.last_update_check = datetime.now().isoformat(timespec="seconds")
@@ -8618,6 +8620,8 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
                     logger.info(f"Update {info['version']} available but skipped by user")
                     return
             except Exception:
+                # Unreadable config. Failing open (showing the dialog) is the
+                # safe direction: worst case the user skips the version again.
                 pass
 
         logger.info(f"Update available: {info['version']}")
@@ -8637,20 +8641,22 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
             "",
             "Updating installs both ImageDescriber and the idt command-line tool.",
         ]
+        # Built outside the list literal: a string wrapped across lines inside a
+        # list reads like a missing comma (and CodeQL flags it as one).
         if can_install and sys.platform == "darwin":
-            lines += [
-                "",
+            how = (
                 "The disk image will be downloaded to your Downloads folder and "
                 "shown in Finder. Quit ImageDescriber, then drag the new "
-                "ImageDescriber to Applications.",
-            ]
+                "ImageDescriber to Applications."
+            )
+            lines += ["", how]
         elif can_install:
-            lines += [
-                "",
+            how = (
                 "ImageDescriber will close and the installer will run. Windows "
                 "will ask for administrator permission, because IDT installs to "
-                "the root of your system drive.",
-            ]
+                "the root of your system drive."
+            )
+            lines += ["", how]
         else:
             lines += ["", "The releases page will open in your browser."]
         if notes:

--- a/imagedescriber/imagedescriber_wx.py
+++ b/imagedescriber/imagedescriber_wx.py
@@ -821,6 +821,11 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
         # Cache AI models on startup for faster dialog opening
         wx.CallAfter(self.refresh_ai_models_silent)
 
+        # Silent update check. Delayed rather than CallAfter so it never competes
+        # with the window actually appearing, and so a modal raised from it has a
+        # shown frame to parent to.
+        wx.CallLater(3000, self._auto_check_updates)
+
     # Note: update_window_title() is now provided by ModifiedStateMixin
     # It automatically handles the modified state indicator (*)
     # TODO: Implement proper tab order - requires controls to be siblings or NavigationEnabled
@@ -1722,6 +1727,20 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
 
         report_issue_item = help_menu.Append(wx.ID_ANY, "&Report an Issue...")
         self.Bind(wx.EVT_MENU, self.on_report_issue, report_issue_item)
+
+        # Accelerators: U is taken by "&User Guide" and A by "&About", so these
+        # use D and K. A duplicate letter cycles instead of activating.
+        check_updates_item = help_menu.Append(wx.ID_ANY, "Check for Up&dates...")
+        self.Bind(wx.EVT_MENU, self.on_check_for_updates, check_updates_item)
+
+        # Checked item rather than a Configure Settings page: the Configure
+        # dialog's category tabs render settings through a ListBox plus an edit
+        # dialog, so a live checkbox does not fit there.
+        self.auto_update_item = help_menu.AppendCheckItem(
+            wx.ID_ANY, "Automatically Chec&k for Updates"
+        )
+        self.auto_update_item.Check(self._get_auto_check_updates())
+        self.Bind(wx.EVT_MENU, self.on_toggle_auto_updates, self.auto_update_item)
 
         help_menu.AppendSeparator()
 
@@ -8483,6 +8502,318 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
             webbrowser.open(new_issue_url)
         except Exception as e:
             show_error(self, f"Could not open issue page:\n{e}")
+
+    # ------------------------------------------------------------------ #
+    #  Update checking (see idt_core/updater.py)                          #
+    # ------------------------------------------------------------------ #
+
+    def _get_auto_check_updates(self):
+        """Whether the startup check is enabled. Defaults on if config is unreadable."""
+        try:
+            from idt_core.config import UserConfig
+            return UserConfig.load().auto_check_updates
+        except Exception:
+            return True
+
+    def on_toggle_auto_updates(self, event):
+        """Persist the Help menu's 'Automatically Check for Updates' toggle."""
+        enabled = self.auto_update_item.IsChecked()
+        try:
+            from idt_core.config import UserConfig
+            cfg = UserConfig.load()
+            cfg.auto_check_updates = enabled
+            cfg.save()
+            logger.info(f"Automatic update checks {'enabled' if enabled else 'disabled'}")
+        except Exception as e:
+            logger.error(f"Could not save update preference: {e}", exc_info=True)
+            show_error(self, f"Could not save that preference:\n{e}")
+
+    def _auto_check_updates(self):
+        """Silent startup check. Says nothing at all unless there is an update."""
+        try:
+            from idt_core import updater
+            from idt_core.config import UserConfig
+
+            # Nothing to replace when running from source.
+            if not updater.is_frozen():
+                return
+
+            cfg = UserConfig.load()
+            if not cfg.auto_check_updates:
+                return
+
+            # Once a day, not once a launch.
+            if cfg.last_update_check:
+                try:
+                    last = datetime.fromisoformat(cfg.last_update_check)
+                    if (datetime.now() - last).total_seconds() < 24 * 3600:
+                        return
+                except ValueError:
+                    pass
+
+            cfg.last_update_check = datetime.now().isoformat(timespec="seconds")
+            cfg.save()
+        except Exception as e:
+            logger.warning(f"Skipping automatic update check: {e}")
+            return
+
+        self._start_update_check(silent=True)
+
+    def on_check_for_updates(self, event=None):
+        """Help > Check for Updates. Always runs; ignores the throttle and any skip."""
+        self._start_update_check(silent=False)
+
+    def _start_update_check(self, silent):
+        if getattr(self, "_update_check_running", False):
+            return
+        self._update_check_running = True
+        if not silent:
+            self.statusbar.SetStatusText("Checking for updates...", 0)
+        threading.Thread(
+            target=self._update_check_worker, args=(silent,), daemon=True
+        ).start()
+
+    def _update_check_worker(self, silent):
+        """Background thread: one HTTP GET, then hand the result back to the UI."""
+        info, error = None, None
+        try:
+            from idt_core import updater
+            info = updater.check_for_update()
+        except Exception as e:
+            error = e
+        wx.CallAfter(self._on_update_check_done, silent, info, error)
+
+    def _on_update_check_done(self, silent, info, error):
+        """UI thread: report what the check found."""
+        self._update_check_running = False
+        # The check can return after the window is gone.
+        if not self or not self.IsShown():
+            return
+        if not silent:
+            self.statusbar.SetStatusText("", 0)
+
+        if error is not None:
+            logger.warning(f"Update check failed: {error}")
+            if not silent:
+                show_error(self, f"Couldn't check for updates:\n{error}")
+            return
+
+        if info is None:
+            logger.info("Update check: already up to date")
+            if not silent:
+                from idt_core import updater
+                running = updater.current_version()
+                wx.MessageBox(
+                    f"ImageDescriber {running} is up to date." if running
+                    else "No newer version was found.",
+                    "No Updates", wx.OK | wx.ICON_INFORMATION, self
+                )
+            return
+
+        # A version the user skipped is only suppressed for the silent check.
+        if silent:
+            try:
+                from idt_core.config import UserConfig
+                if UserConfig.load().skipped_update_version == info["version"]:
+                    logger.info(f"Update {info['version']} available but skipped by user")
+                    return
+            except Exception:
+                pass
+
+        logger.info(f"Update available: {info['version']}")
+        self._show_update_dialog(info)
+
+    def _show_update_dialog(self, info):
+        from idt_core import updater
+
+        can_install = bool(info.get("url")) and updater.is_frozen()
+
+        notes = (info.get("notes") or "").strip()
+        if len(notes) > 600:
+            notes = notes[:600].rstrip() + "\n..."
+
+        lines = [
+            f"Version {info['version']} is available. You have {updater.current_version()}.",
+            "",
+            "Updating installs both ImageDescriber and the idt command-line tool.",
+        ]
+        if can_install and sys.platform == "darwin":
+            lines += [
+                "",
+                "The disk image will be downloaded to your Downloads folder and "
+                "shown in Finder. Quit ImageDescriber, then drag the new "
+                "ImageDescriber to Applications.",
+            ]
+        elif can_install:
+            lines += [
+                "",
+                "ImageDescriber will close and the installer will run. Windows "
+                "will ask for administrator permission, because IDT installs to "
+                "the root of your system drive.",
+            ]
+        else:
+            lines += ["", "The releases page will open in your browser."]
+        if notes:
+            lines += ["", "What's new:", notes]
+
+        dlg = wx.MessageDialog(
+            self, "\n".join(lines), "Update Available",
+            wx.YES_NO | wx.CANCEL | wx.ICON_INFORMATION
+        )
+        dlg.SetYesNoCancelLabels(
+            "&Download" if can_install else "&Open Releases Page",
+            "&Skip This Version",
+            "&Later",
+        )
+        result = dlg.ShowModal()
+        dlg.Destroy()
+
+        if result == wx.ID_NO:
+            try:
+                from idt_core.config import UserConfig
+                cfg = UserConfig.load()
+                cfg.skipped_update_version = info["version"]
+                cfg.save()
+                logger.info(f"User skipped update {info['version']}")
+            except Exception as e:
+                logger.error(f"Could not record skipped version: {e}", exc_info=True)
+            return
+
+        if result != wx.ID_YES:
+            return
+
+        if not can_install:
+            try:
+                webbrowser.open(info.get("page_url") or updater.RELEASES_PAGE)
+            except Exception as e:
+                show_error(self, f"Could not open the releases page:\n{e}")
+            return
+
+        self._download_update(info)
+
+    def _download_update(self, info):
+        """Download the installer with a cancellable progress dialog.
+
+        The worker thread deliberately does NOT wx.CallAfter into the dialog.
+        wx.ProgressDialog.Update() yields for UI events internally, so a
+        CallAfter posted while the main thread sits inside Update() gets
+        dispatched *from within it* — and a completion callback that destroys the
+        dialog then frees it while its own Update() is still on the C++ stack,
+        which segfaults. Instead the worker writes plain counters and a timer on
+        the main thread reads them, so Update() and Destroy() can never nest.
+        """
+        from idt_core import updater
+
+        self._update_dl_cancelled = False
+        self._update_dl_done_bytes = 0
+        self._update_dl_total_bytes = 0
+        self._update_dl_complete = False
+        self._update_dl_in_tick = False
+
+        dlg = wx.ProgressDialog(
+            "Downloading Update",
+            f"Downloading version {info['version']}...",
+            maximum=100, parent=self,
+            style=wx.PD_APP_MODAL | wx.PD_CAN_ABORT | wx.PD_AUTO_HIDE
+        )
+
+        result = {"path": None, "error": None}
+        timer = wx.Timer(self)
+
+        def on_progress(done, total):
+            # Worker thread: plain int stores, no wx calls.
+            self._update_dl_done_bytes = done
+            self._update_dl_total_bytes = total
+
+        def worker():
+            try:
+                result["path"] = updater.download_asset(
+                    info["url"],
+                    progress=on_progress,
+                    should_cancel=lambda: self._update_dl_cancelled,
+                    checksums_url=info.get("checksums_url"),
+                )
+            except Exception as e:
+                result["error"] = e
+            self._update_dl_complete = True
+
+        def on_tick(event):
+            # A timer event can itself be dispatched from inside Update()'s
+            # yield; this guard is what keeps Destroy() out of that stack.
+            if self._update_dl_in_tick:
+                return
+            self._update_dl_in_tick = True
+            try:
+                if self._update_dl_complete:
+                    timer.Stop()
+                    self.Unbind(wx.EVT_TIMER, handler=on_tick)
+                    dlg.Destroy()
+                    finish()
+                    return
+
+                done = self._update_dl_done_bytes
+                total = self._update_dl_total_bytes
+                mb = 1024 * 1024
+                if total:
+                    keep_going, _ = dlg.Update(
+                        min(99, int(done * 100 / total)),
+                        f"Downloaded {done // mb} MB of {total // mb} MB"
+                    )
+                else:
+                    # An indeterminate bar beats a percentage that lies.
+                    keep_going, _ = dlg.Pulse(f"Downloaded {done // mb} MB")
+                if not keep_going:
+                    self._update_dl_cancelled = True
+            finally:
+                self._update_dl_in_tick = False
+
+        def finish():
+            if result["error"] is not None:
+                logger.error(f"Update download failed: {result['error']}")
+                show_error(self, f"Couldn't download the update:\n{result['error']}")
+                return
+            if result["path"] is None:
+                logger.info("Update download cancelled")
+                return
+            path = result["path"]
+            logger.info(f"Update downloaded to {path}")
+
+            # Catch the common launch failures (antivirus quarantine, a vanished
+            # temp file) while there is still a window to show the error on.
+            if not os.path.exists(path):
+                show_error(self, "The downloaded installer is no longer on disk. "
+                                 "Antivirus software may have removed it.")
+                return
+
+            # On Windows the installer replaces the running executables, so the
+            # app has to be gone before it starts. Close() runs the unsaved-changes
+            # prompt and returns False if the user backs out — in which case the
+            # installer must not run at all. Launching it first would leave Setup
+            # racing a still-open app while the user decides whether to save.
+            if sys.platform != "darwin":
+                if not self.Close():
+                    logger.info("Update postponed: window close was cancelled")
+                    wx.MessageBox(
+                        f"Update not installed.\n\nThe installer is saved at:\n{path}\n\n"
+                        "Run it any time to finish updating.",
+                        "Update Postponed", wx.OK | wx.ICON_INFORMATION, self
+                    )
+                    return
+
+            try:
+                updater.launch_installer(path)
+            except Exception as e:
+                logger.error(f"Could not launch installer: {e}", exc_info=True)
+                # This frame is already closing, so it cannot parent a dialog.
+                wx.MessageBox(
+                    f"Couldn't start the installer:\n{e}\n\n"
+                    f"It is saved at:\n{path}",
+                    "Update Failed", wx.OK | wx.ICON_ERROR, None
+                )
+
+        self.Bind(wx.EVT_TIMER, on_tick, timer)
+        timer.Start(150)
+        threading.Thread(target=worker, daemon=True).start()
 
     def on_about(self, event=None):
         """Show about dialog with version and feature information"""

--- a/imagedescriber/imagedescriber_wx.spec
+++ b/imagedescriber/imagedescriber_wx.spec
@@ -1,5 +1,6 @@
 # -*- mode: python ; coding: utf-8 -*-
 
+import re
 import sys
 from pathlib import Path
 from PyInstaller.utils.hooks import collect_all
@@ -95,6 +96,7 @@ a = Analysis(
         'idt_core.config',
         'idt_core.config_loader',
         'idt_core.converter',
+        'idt_core.updater',
         'idt_core.progress',
         'idt_core.watcher',
         'idt_core.downloader',
@@ -217,10 +219,11 @@ version_file = project_root / 'VERSION'
 version = '4.0.0'  # Fallback
 if version_file.exists():
     version_text = version_file.read_text().strip()
-    # Extract just the version number (e.g., "4.0.0Beta1 bld050" -> "4.0.0")
-    version = version_text.split()[0].rstrip('Beta1234567890')
-    if not version:
-        version = '4.0.0'
+    # Extract just the numeric version (e.g. "4.0.0Beta1 bld050" -> "4.0.0").
+    # A previous rstrip('Beta1234567890') also ate the trailing digit of a plain
+    # version, so "4.5.0" became "4.5." and CFBundleShortVersionString was invalid.
+    match = re.match(r'\d+(?:\.\d+)*', version_text)
+    version = match.group(0) if match else '4.0.0'
 
 # macOS .app bundle
 app = BUNDLE(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,11 @@ fail_under = 23
 "imagedescriber/imagedescriber_wx.py" = 18.0
 "imagedescriber/viewer_components.py" = 23.0
 "idt_core/gui_bridge.py" = 78.0
+# Measured 86.75%. Defended because this module downloads a binary and hands it
+# to os.startfile: the checksum, URL-allowlist and partial-file-cleanup paths
+# must stay tested. Uncovered remainder is the platform branches that cannot run
+# on the CI OS (macOS reveal, os.startfile).
+"idt_core/updater.py" = 85.0
 "idt_core/providers/base.py" = 100.0
 "idt_core/providers/claude.py" = 45.0
 "idt_core/providers/ollama.py" = 48.0

--- a/pytest_tests/test_updater.py
+++ b/pytest_tests/test_updater.py
@@ -1,0 +1,421 @@
+"""Unit tests for idt_core.updater — the in-app update check.
+
+Mirrors the coverage Scores/tests/unit/test_updater.py has for the same logic.
+Nothing here touches the network: _fetch_releases is patched, or a file:// feed
+fixture is used.
+"""
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from idt_core import updater
+
+pytestmark = pytest.mark.unit
+
+
+# ---------------------------------------------------------------- #
+# Version comparison                                                #
+# ---------------------------------------------------------------- #
+
+@pytest.mark.parametrize("latest,current,expected", [
+    ("4.5.1", "4.5.0", True),
+    ("4.6.0", "4.5.9", True),
+    ("5.0.0", "4.9.9", True),
+    ("4.5.0", "4.5.0", False),
+    ("4.5.0", "4.5.1", False),
+    ("4.4.9", "4.5.0", False),
+    # Zero-pad: 4.5 and 4.5.0 are the same version.
+    ("4.5", "4.5.0", False),
+    ("4.5.0", "4.5", False),
+    ("4.5.1", "4.5", True),
+    # Numeric, not lexicographic: 4.10 is above 4.9.
+    ("4.10.0", "4.9.0", True),
+])
+def test_is_newer(latest, current, expected):
+    assert updater.is_newer(latest, current) is expected
+
+
+def test_is_newer_handles_unparseable_current():
+    """A missing/garbage current version must not crash the check."""
+    assert updater.is_newer("4.5.0", "") is True
+
+
+# ---------------------------------------------------------------- #
+# Tag parsing                                                       #
+# ---------------------------------------------------------------- #
+
+@pytest.mark.parametrize("tag,expected", [
+    ("v4.5.0", "4.5.0"),
+    ("v10.0.1", "10.0.1"),
+    ("v5", "5"),
+    # The remainder must be purely numeric, so none of these are stable releases.
+    ("v4beta2", None),        # this repo's own old tag style
+    ("v4.0.0Beta3", None),    # ditto — must not parse as 4.0.0.3
+    ("v4.5.0-rc1", None),
+    ("viewer-fix", None),
+    ("4.5.0", None),          # no prefix
+    ("", None),
+    (None, None),
+])
+def test_release_version(tag, expected):
+    assert updater._release_version(tag) == expected
+
+
+# ---------------------------------------------------------------- #
+# Asset selection                                                   #
+# ---------------------------------------------------------------- #
+
+def _release(*asset_names, tag="v4.9.0", **kw):
+    rel = {
+        "tag_name": tag,
+        "body": "Notes.",
+        "html_url": f"https://github.com/kellylford/Image-Description-Toolkit/releases/tag/{tag}",
+        "assets": [
+            {"name": n, "browser_download_url": f"https://example.invalid/{n}"}
+            for n in asset_names
+        ],
+    }
+    rel.update(kw)
+    return rel
+
+
+WIN_ASSET = "ImageDescriptionToolkitSetup-4.9.0-windows.exe"
+MAC_ASSET = "IDT-4.9.0-macos-arm64.dmg"
+OTHER_ASSETS = ["idt-4.9.0-windows-x64.exe", "ImageDescriber-4.9.0-windows-x64.exe",
+                "idt-4.9.0-macos-arm64.tar.gz", "SHA256SUMS.txt"]
+
+
+def test_asset_picks_windows_installer(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    url = updater.asset_for_platform(_release(*OTHER_ASSETS, WIN_ASSET, MAC_ASSET))
+    assert url.endswith(WIN_ASSET)
+
+
+def test_asset_picks_macos_dmg(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    url = updater.asset_for_platform(_release(*OTHER_ASSETS, WIN_ASSET, MAC_ASSET))
+    assert url.endswith(MAC_ASSET)
+
+
+def test_asset_accepts_locally_built_installer_name(monkeypatch):
+    """builditall_wx.bat produces an underscore name; CI produces a hyphen one."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    url = updater.asset_for_platform(_release("ImageDescriptionToolkitSetup_4.9.0.exe"))
+    assert url.endswith("ImageDescriptionToolkitSetup_4.9.0.exe")
+
+
+def test_asset_none_when_only_other_platform(monkeypatch):
+    """Never offer a Windows user a .dmg — the caller falls back to the web page."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert updater.asset_for_platform(_release(MAC_ASSET, *OTHER_ASSETS)) is None
+
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert updater.asset_for_platform(_release(WIN_ASSET, *OTHER_ASSETS)) is None
+
+
+def test_asset_none_when_no_assets(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert updater.asset_for_platform({"tag_name": "v4.9.0"}) is None
+
+
+# ---------------------------------------------------------------- #
+# check_for_update                                                  #
+# ---------------------------------------------------------------- #
+
+@pytest.fixture
+def feed(monkeypatch):
+    """Replace the network fetch with a list the test controls."""
+    releases = []
+
+    def _fetch():
+        return releases
+
+    monkeypatch.setattr(updater, "_fetch_releases", _fetch)
+    monkeypatch.setattr(sys, "platform", "win32")
+    return releases
+
+
+def test_finds_newer_release(feed):
+    feed.append(_release(WIN_ASSET, tag="v4.9.0"))
+    info = updater.check_for_update(current="4.5.0")
+    assert info["version"] == "4.9.0"
+    assert info["url"].endswith(WIN_ASSET)
+    assert info["notes"] == "Notes."
+    assert info["page_url"].endswith("v4.9.0")
+
+
+def test_none_when_up_to_date(feed):
+    feed.append(_release(WIN_ASSET, tag="v4.5.0"))
+    assert updater.check_for_update(current="4.5.0") is None
+
+
+def test_none_when_running_ahead_of_latest(feed):
+    """A dev build past the last release must not be told to downgrade."""
+    feed.append(_release(WIN_ASSET, tag="v4.5.0"))
+    assert updater.check_for_update(current="4.6.0") is None
+
+
+def test_skips_drafts_and_prereleases(feed):
+    feed.extend([
+        _release(WIN_ASSET, tag="v4.9.0", draft=True),
+        _release(WIN_ASSET, tag="v4.8.0", prerelease=True),
+        _release(WIN_ASSET, tag="v4.7.0"),
+    ])
+    info = updater.check_for_update(current="4.5.0")
+    assert info["version"] == "4.7.0"
+
+
+def test_skips_non_release_tags(feed):
+    feed.extend([
+        _release(WIN_ASSET, tag="v4beta2"),
+        _release(WIN_ASSET, tag="viewer-fix"),
+        _release(WIN_ASSET, tag="v4.6.0"),
+    ])
+    info = updater.check_for_update(current="4.5.0")
+    assert info["version"] == "4.6.0"
+
+
+def test_picks_highest_not_first(feed):
+    """GitHub's ordering is not guaranteed to put the highest version first."""
+    feed.extend([
+        _release(WIN_ASSET, tag="v4.6.0"),
+        _release(WIN_ASSET, tag="v4.10.0"),
+        _release(WIN_ASSET, tag="v4.9.0"),
+    ])
+    assert updater.check_for_update(current="4.5.0")["version"] == "4.10.0"
+
+
+def test_url_is_none_when_platform_asset_missing(feed):
+    """Still reports the update — the caller sends the user to the web page."""
+    feed.append(_release(MAC_ASSET, tag="v4.9.0"))
+    info = updater.check_for_update(current="4.5.0")
+    assert info["version"] == "4.9.0"
+    assert info["url"] is None
+
+
+def test_none_when_feed_empty(feed):
+    assert updater.check_for_update(current="4.5.0") is None
+
+
+def test_network_failure_propagates(monkeypatch):
+    """Must raise, so a manual check says 'couldn't check' rather than 'up to date'."""
+    def _boom():
+        raise ConnectionError("no route to host")
+
+    monkeypatch.setattr(updater, "_fetch_releases", _boom)
+    with pytest.raises(ConnectionError):
+        updater.check_for_update(current="4.5.0")
+
+
+# ---------------------------------------------------------------- #
+# Feed override                                                     #
+# ---------------------------------------------------------------- #
+
+def test_releases_url_default(monkeypatch):
+    monkeypatch.delenv("IDT_UPDATE_FEED", raising=False)
+    assert updater.releases_url() == updater.DEFAULT_RELEASES_URL
+
+
+def test_file_feed_override(tmp_path, monkeypatch):
+    """IDT_UPDATE_FEED with a file:// URL drives the whole flow offline."""
+    monkeypatch.setattr(sys, "platform", "win32")
+    fixture = tmp_path / "releases.json"
+    fixture.write_text(json.dumps([_release(WIN_ASSET, tag="v4.9.0")]), encoding="utf-8")
+    monkeypatch.setenv("IDT_UPDATE_FEED", fixture.as_uri())
+
+    info = updater.check_for_update(current="4.5.0")
+    assert info["version"] == "4.9.0"
+
+
+# ---------------------------------------------------------------- #
+# Version source                                                    #
+# ---------------------------------------------------------------- #
+
+def test_current_version_matches_package():
+    """The checker must compare against idt_core.__version__, not a file lookup."""
+    from idt_core import __version__
+    assert updater.current_version() == __version__
+    assert updater.current_version() != "1.0.0"  # wx_common's bad fallback
+
+
+def test_unknown_current_version_suppresses_check(feed, monkeypatch):
+    """Not knowing our version must stay quiet, not report a phantom update.
+
+    A "0.0.0" style fallback would make every release look newer, nagging the
+    user to reinstall on every launch forever.
+    """
+    feed.append(_release(WIN_ASSET, tag="v4.9.0"))
+    monkeypatch.setattr(updater, "current_version", lambda: None)
+    assert updater.check_for_update() is None
+
+
+# ---------------------------------------------------------------- #
+# Download URL trust                                                #
+# ---------------------------------------------------------------- #
+
+@pytest.mark.parametrize("url", [
+    "https://github.com/kellylford/Image-Description-Toolkit/releases/download/v1/a.exe",
+    "https://objects.githubusercontent.com/x/a.exe",
+    "https://github-releases.githubusercontent.com/x/a.dmg",
+])
+def test_download_url_allowed(url):
+    assert updater._validate_download_url(url) == url
+
+
+@pytest.mark.parametrize("url", [
+    "http://github.com/x/a.exe",             # not https
+    "https://evil.invalid/a.exe",
+    "https://github.com.evil.invalid/a.exe",  # suffix trick
+    "https://notgithub.com/a.exe",
+    "file:///C:/Windows/System32/calc.exe",
+    "",
+    None,
+])
+def test_download_url_rejected(url):
+    """IDT_UPDATE_FEED must not become a way to fetch and run an arbitrary binary."""
+    with pytest.raises(ValueError):
+        updater._validate_download_url(url)
+
+
+# ---------------------------------------------------------------- #
+# Checksums                                                         #
+# ---------------------------------------------------------------- #
+
+def test_checksums_for_finds_asset():
+    rel = _release(WIN_ASSET, "SHA256SUMS.txt")
+    assert updater.checksums_for(rel).endswith("SHA256SUMS.txt")
+
+
+def test_checksums_for_absent():
+    assert updater.checksums_for(_release(WIN_ASSET)) is None
+
+
+def test_check_for_update_exposes_checksums(feed):
+    feed.append(_release(WIN_ASSET, "SHA256SUMS.txt", tag="v4.9.0"))
+    info = updater.check_for_update(current="4.5.0")
+    assert info["checksums_url"].endswith("SHA256SUMS.txt")
+
+
+class _Resp:
+    def __init__(self, text):
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+def test_expected_sha256_parses(monkeypatch):
+    body = (
+        "aaaa1111  ImageDescriber-4.9.0-windows-x64.exe\n"
+        "bbbb2222  ImageDescriptionToolkitSetup-4.9.0-windows.exe\n"
+        "cccc3333 *IDT-4.9.0-macos-arm64.dmg\n"
+    )
+    monkeypatch.setattr(updater.requests, "get", lambda *a, **k: _Resp(body))
+    url = "https://github.com/x/SHA256SUMS.txt"
+    assert updater.expected_sha256(url, "ImageDescriptionToolkitSetup-4.9.0-windows.exe") == "bbbb2222"
+    # sha256sum's binary-mode "*" prefix must not defeat the match.
+    assert updater.expected_sha256(url, "IDT-4.9.0-macos-arm64.dmg") == "cccc3333"
+    assert updater.expected_sha256(url, "not-listed.exe") is None
+
+
+def test_expected_sha256_none_without_url():
+    assert updater.expected_sha256(None, "anything.exe") is None
+
+
+# ---------------------------------------------------------------- #
+# download_asset                                                    #
+# ---------------------------------------------------------------- #
+
+GOOD_URL = "https://github.com/kellylford/Image-Description-Toolkit/releases/download/v4.9.0/Setup.exe"
+PAYLOAD = b"x" * (65536 * 3 + 17)
+
+
+class _Stream:
+    """Minimal stand-in for a streamed requests response."""
+
+    def __init__(self, payload, length=True):
+        self._payload = payload
+        self.headers = {"Content-Length": str(len(payload))} if length else {}
+
+    def raise_for_status(self):
+        pass
+
+    def iter_content(self, chunk_size=65536):
+        for i in range(0, len(self._payload), chunk_size):
+            yield self._payload[i:i + chunk_size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pytest.fixture
+def dl(tmp_path, monkeypatch):
+    monkeypatch.setattr(updater, "download_dir", lambda: tmp_path)
+    monkeypatch.setattr(updater.requests, "get",
+                        lambda *a, **k: _Stream(PAYLOAD))
+    return tmp_path
+
+
+def test_download_writes_file_and_reports_progress(dl):
+    seen = []
+    path = updater.download_asset(GOOD_URL, progress=lambda d, t: seen.append((d, t)))
+    assert Path(path).read_bytes() == PAYLOAD
+    assert seen[-1] == (len(PAYLOAD), len(PAYLOAD))
+
+
+def test_download_verifies_checksum(dl, monkeypatch):
+    good = hashlib.sha256(PAYLOAD).hexdigest()
+    monkeypatch.setattr(updater, "expected_sha256", lambda u, n: good)
+    path = updater.download_asset(GOOD_URL, checksums_url="https://github.com/x/S.txt")
+    assert Path(path).exists()
+
+
+def test_download_rejects_bad_checksum_and_deletes(dl, monkeypatch):
+    """We are about to execute this file, so a mismatch must not survive on disk."""
+    monkeypatch.setattr(updater, "expected_sha256", lambda u, n: "deadbeef")
+    with pytest.raises(ValueError, match="checksum"):
+        updater.download_asset(GOOD_URL, checksums_url="https://github.com/x/S.txt")
+    assert list(dl.iterdir()) == []
+
+
+def test_download_cancel_deletes_partial(dl):
+    path = updater.download_asset(GOOD_URL, should_cancel=lambda: True)
+    assert path is None
+    assert list(dl.iterdir()) == []
+
+
+def test_download_error_deletes_partial(dl, monkeypatch):
+    """A mid-stream failure must not leave a half-installer in temp."""
+    class _Boom(_Stream):
+        def iter_content(self, chunk_size=65536):
+            yield b"x" * chunk_size
+            raise ConnectionError("dropped")
+
+    monkeypatch.setattr(updater.requests, "get", lambda *a, **k: _Boom(PAYLOAD))
+    with pytest.raises(ConnectionError):
+        updater.download_asset(GOOD_URL)
+    assert list(dl.iterdir()) == []
+
+
+def test_download_refuses_untrusted_url(dl):
+    with pytest.raises(ValueError):
+        updater.download_asset("https://evil.invalid/Setup.exe")
+    assert list(dl.iterdir()) == []
+
+
+def test_version_file_agrees_with_package():
+    """VERSION, idt_core.__version__ and pyproject.toml are hand-synced.
+
+    release.yml enforces this at tag time; catching drift here means a developer
+    sees it before pushing rather than after a failed release.
+    """
+    from pathlib import Path
+    root = Path(__file__).parent.parent
+    assert (root / "VERSION").read_text(encoding="utf-8").strip() == updater.current_version()


### PR DESCRIPTION
An installed copy of IDT had no way to learn that a newer release existed. Both tools now check GitHub Releases.

## What this adds

**ImageDescriber** — Help menu gains **Check for Updates...** and **Automatically Check for Updates** (on by default, once a day at most, shortly after launch). The silent check says nothing unless there is an update. Finding one offers **Download** / **Skip This Version** / **Later**.

- **Windows:** downloads the Inno installer and runs it *after* the app closes.
- **macOS:** saves the DMG to `~/Downloads` and reveals it in Finder — a DMG cannot install over a running app.

**CLI** — `idt update`, notify-only. One installer updates both tools, so a CLI-only download path would be redundant.

## Why not Velopack

QuickMail and GHManage use Velopack for silent self-update. Here that would mean replacing Inno Setup, relocating the install off `C:\idt`, and reimplementing the installer's `IDT_CONFIG_DIR` registry write, PATH addition, and winget-Ollama step — plus migrating existing 4.x installs. Filed for 5.0. This follows Scores/FastWeather instead.

## Notable details

- Version comes from `idt_core.__version__`, not `wx_common.get_app_version()` (which falls back to `"1.0.0"` and would report being three majors behind). `release.yml`'s validate job now gates on `VERSION`, `idt_core/__init__.py` and `pyproject.toml` all matching the tag.
- `current_version()` returns `None` rather than a low sentinel — a `"0.0.0"` fallback would make every release look newer and nag forever.
- Tag parsing is strictly numeric, so this repo's own `v4beta2` / `v4.0.0Beta3` tags are not mistaken for stable releases.
- The download is SHA256-verified against the release's `SHA256SUMS.txt` and restricted to HTTPS GitHub hosts, because the result gets executed.
- Progress uses a `wx.Timer` reading worker-written counters rather than a `CallAfter` per chunk: `ProgressDialog.Update()` yields for UI events, so a completion callback could otherwise be dispatched from inside it and destroy the dialog mid-call.
- Also fixes the `.app` bundle version — `rstrip('Beta1234567890')` turned `"4.5.0"` into `"4.5."`, an invalid `CFBundleShortVersionString`.

## Testing

- 61 new updater tests; full suite **1011 passed, 14 skipped**
- GUI handler harness: 7/7 branches (update found, skip persists, silent check honours skip, up-to-date, unreachable feed reports honestly, preference round-trip)
- Frozen mode: both exes rebuilt; `idt.exe update` verified against live GitHub and a `file://` fixture feed
- `installer.iss` compiles; `release.yml` gate simulated (passes synced, fails on mismatch)

## Not tested

- **The real download-and-install path** — no release newer than 4.5.0 exists yet, so nothing has actually been fetched from GitHub and executed.
- **All macOS behaviour** — built and tested on Windows only.
- The `Update()`/`Destroy()` crash was never reproduced naturally (0/22 by review, 0/25 here against the old code). The mechanism was proven under forced conditions; this removes it structurally.

See `docs/WorkTracking/2026-08-10-session-summary.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)