### PR TITLE
docs: session summary for 2026-08-13 dependabot recovery

### DIFF
--- a/docs/WorkTracking/2026-08-13-session-summary-dependabot.md
+++ b/docs/WorkTracking/2026-08-13-session-summary-dependabot.md
@@ -1,0 +1,167 @@
+# 2026-08-13 Session Summary — Dependabot recovery
+
+Restarted dependabot after a three-week outage, merged the resulting backlog,
+repaired a long-standing corruption in the root `requirements.txt`, and
+verified the `download-artifact` v8 bump against the real release pipeline.
+
+## The original problem
+
+Every entry in `.github/dependabot.yml` carried `target-branch: "v4.5"`. That
+branch had been merged and deleted, so dependabot was opening PRs against a ref
+that no longer existed and failing silently — no error, no PRs, since
+**2026-07-21**.
+
+It went unnoticed because `GET /repos/.../branches/v4.5` returns 200: GitHub
+redirects a deleted branch to the default branch, so the branch *looks* alive
+unless you check `git ls-remote`, which returns no ref for it.
+
+PR #236 (removing the key, opened 2026-08-03) was already written, green on all
+six checks, and simply sitting unmerged.
+
+## What was done
+
+### 1. Merged #236 — `19c806a`
+
+Dependabot woke up **74 seconds later** and opened 10 PRs, all correctly based
+on `main`. The previous batch (#218–#222) had all targeted `v4.5`. That timing
+is the proof the fix worked.
+
+### 2. Merged the backlog — 10 PRs, 8 auto-closed as superseded
+
+| PR | Change | Merge |
+|---|---|---|
+| #243 | pillow-heif 0.16 → 1.5.0 (show_metadata) | `5b3a33d` |
+| #242 | anthropic 0.116.0 → 0.121.0 | `09176d7` |
+| #247 | tqdm 4.68.4 → 4.70.0 (idt) | `15cdda9` |
+| #245 | pyinstaller 6.21.0 → 6.22.0 (imagedescriber) | `efbb7e9` |
+| #244 | openai 2.44.0 → 2.53.0 | `3c09b16` |
+| #249 | setuptools 83.0.0 → 84.0.0 | `b4592e5` |
+| #246 | pyinstaller 6.21.0 → 6.22.0 (idt) | `10725dd` |
+| #251 | numpy 2.5.0 → 2.5.2 (idt) | `197b9f7` |
+| #250 | pillow-heif 1.4.0 → 1.5.0 (imagedescriber) | `5b5433d` |
+| #252 | wxPython 4.2.5 → 4.3.1 | `54de526` |
+| #258 | actions/download-artifact v7 → v8 | `0d7eb23` |
+
+Auto-closed by dependabot as redundant: #248, #253–#257.
+
+Merge order mattered — `imagedescriber/requirements.txt` was touched by 5 PRs
+and `idt/requirements.txt` by 5. Broadest first (#242, #244), then the narrow
+ones. No conflicts materialised; dependabot's edits land on different lines
+within the shared files.
+
+### 3. PR #259 — root floor alignment + comment repair — `3c1a297`
+
+**Floors.** Dependabot closed #253 (pyinstaller) and #256 (tqdm) with *"Looks
+like X is up-to-date now"* because the per-app bumps satisfied its check. Both
+PRs also covered the root `requirements.txt`, which never got updated — and
+dependabot now considers them current, so **it will not re-propose them**.
+Aligned by hand: pillow-heif ×2 → 1.5.0, numpy → 2.5.2, tqdm → 4.70.0,
+pyinstaller → 6.22.0, plus imagedescriber's tqdm → 4.70.0.
+
+**Comment corruption.** The INSTALLATION EXAMPLES footer had been mangled since
+`29e3c45` (2026-01-08, wxPython migration) — about seven months. That commit
+meant to *replace* the block but mis-anchored both ends:
+
+- Start landed mid-banner, leaving the old block intact and opening the
+  replacement with `# ======================CLI/scripts only, no video, no HEIC):`
+- End landed mid-line, truncating `#   cd idtconfigure && pip install -r requirements.txt`
+  to `cd idtconfigure && ` and fusing it onto `#   - OpenAI: Set OPENAI_API_KEY ...`,
+  swallowing the entire NOTES banner, the Python 3.13 compatibility notes and
+  the `API Keys Required:` header.
+
+Restored from `29e3c45^`. Also corrected the app directories named in **both**
+the header and the examples: they listed `viewer/`, `prompt_editor/` and
+`idtconfigure/`, none of which still exist — those UIs are integrated into
+ImageDescriber. The two real standalone apps are `idt/` and `imagedescriber/`.
+
+### 4. Release pipeline dry run — download-artifact v8
+
+`download-artifact` appears only in `release.yml`, which triggers solely on
+`push: tags: v*`. None of #258's six checks exercised it, so it merged
+unverified against the one path it affects.
+
+Ran a dry run on scratch branch `test/artifact-v8-dryrun` with tag `v4.5.99`
+and `Create release` gated behind `if: false`. Result: **success**, publishing
+skipped.
+
+```
+skip-decompress: false
+digest-mismatch: error          <- v8's new failing default was active
+Found 5 artifact(s)             <- all with Expected Digest declared
+...5x "Artifact download completed successfully."
+All five artifacts downloaded, unzipped, and glob-matched.
+Create release ................. skipped
+```
+
+Both v8 breaking changes are no-ops for this pipeline: artifacts are zipped so
+the new `Content-Type` check still decompresses them, and there are no digest
+mismatches for the new error-by-default to escalate. upload-artifact stays on
+v7; no major pairing requirement exists.
+
+Scratch tag and branch deleted afterwards. `main` never carried the `if: false`
+edit or the 4.5.99 version bump.
+
+## Decisions
+
+- **Merged #258 on evidence, not assumption.** Before merging, pulled the logs
+  from release run 31392996638 (v4.5.1) and confirmed all five artifacts arrive
+  as `.zip` blobs with clean digests. The dry run later confirmed it directly.
+- **Dry run rather than a real test release.** `release.yml` publishes with no
+  `draft:`/`prerelease:` flag, and `idt_core/updater.py:177` only skips draft
+  and prerelease entries — so a plain test tag would have offered a throwaway
+  build to every user running 4.5.0 (the same cleanup as the reverted 4.5.1).
+  Gating `Create release` tests the whole artifact path with zero user impact.
+- **Closed nothing manually.** #248 was provably a no-op after #244 (identical
+  edit to the same file); dependabot auto-closed it before intervention.
+- **Left root `requirements.txt`'s duplicate `pillow-heif` entry alone.** It is
+  listed twice by design, in two different sections. Both now read 1.5.0.
+
+## Test results
+
+| Run | Result |
+|---|---|
+| Baseline on `main` before any merge | 1012 passed, 14 skipped |
+| `main` after all dependabot merges | 1012 passed, 14 skipped |
+| PR #259 branch (floors + comment repair) | 1012 passed, 14 skipped |
+| Scratch venv, all new floors + wxPython 4.3.1 | 1012 passed, 14 skipped |
+| CI on all 11 merged PRs | 6/6 green each, zero failures |
+| Release dry run, tag v4.5.99 | success (publish skipped) |
+
+Additional verification:
+
+- All 20 root requirements parse via `packaging.requirements` after the comment
+  repair, markers included.
+- All ten new floors resolve together in a clean venv — the real risk with a
+  simultaneous batch.
+- API surfaces probed against the installed SDKs:
+  `openai.chat.completions.create(model=, messages=, max_tokens=)` exists in
+  3.0.0 (matches `openai_provider.py:79`);
+  `anthropic.messages.create(model=, messages=, max_tokens=, system=, temperature=)`
+  exists in 0.121.0 (matches `claude.py:165`).
+- Repo-wide `pillow_heif` usage is a single stable call,
+  `register_heif_opener()`, across 10 files — verified working on 1.5.0. This is
+  why the 0.16 → 1.5.0 jump in `show_metadata` was safe: the floor was three
+  majors stale, and installs had been resolving to 1.x regardless.
+
+## What was NOT tested
+
+- **The `Create release` step itself on v8.** The dry run gated it off by
+  design. It uses `softprops/action-gh-release@v3`, which is unchanged by #258
+  and consumes the already-staged `release/` directory, so it is not affected by
+  the download-artifact bump — but it did not run in this session.
+- **GUI runtime behaviour on wxPython 4.3.1.** The suite passes and both
+  platform builds succeed, but nobody drove the app by hand. Note CLAUDE.md's
+  warning that wx swallows exceptions in event handlers, so a green suite is
+  weaker evidence here than elsewhere.
+- **The bumped SDKs against live APIs.** No real OpenAI/Anthropic calls were
+  made; only constructor and method-signature probes.
+- **macOS beyond CI.** All local runs were Windows.
+
+## Follow-up worth considering
+
+**`openai` resolves to 3.0.0, not 2.53.0.** Every floor is `>=` with no ceiling,
+so pip takes the newest major. This was already true before this session — the
+old `>=2.44.0` also resolved to 3.0.0. The code is compatible, but the project
+crosses major boundaries unpinned, with no PR to review when the next one lands.
+A `<4`-style ceiling on the SDKs would make that a reviewable event. The same
+applies to `opencv-python>=5.0.0.93` and `numpy`.


### PR DESCRIPTION
Session summary per CLAUDE.md convention.

Covers:
- #236 — dead `v4.5` target-branch fix; dependabot fired 74s after merge
- The 10-PR backlog merge (plus 8 auto-closed as superseded)
- #259 — root floor alignment and the 7-month-old corrupted comment block
- The `download-artifact` v8 dry run on tag `v4.5.99` (publishing gated off)

Includes a **What was NOT tested** section and one follow-up worth considering: the SDK floors are unbounded, so `openai` currently resolves to **3.0.0**, not 2.53.0.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)