### PR TITLE
Rewrite the spec completeness checker, and run it in CI

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -105,6 +105,12 @@ jobs:
     - name: Verify macOS build system structure
       run: bash BuildAndRelease/MacBuilds/verify_macos_build_structure.sh
 
+    # Cheap, and it fails for a reason no build-time error explains well: a
+    # lazily-imported module absent from a spec builds fine and only breaks
+    # when the frozen app calls the function that imports it.
+    - name: Check PyInstaller specs are complete
+      run: ./.venv/bin/python BuildAndRelease/check_spec_completeness.py
+
     - name: Syntax-check core modules
       # compileall over whole packages rather than a hand-listed set of files,
       # so this cannot rot when modules move (it was originally written against

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -56,6 +56,13 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements.txt
     
+    # Runs before the build because it costs seconds and the failure it finds
+    # costs a full packaging cycle: a lazily-imported module missing from a
+    # spec builds cleanly and only breaks when the frozen app reaches the
+    # function that imports it.
+    - name: Check PyInstaller specs are complete
+      run: python BuildAndRelease/check_spec_completeness.py
+
     - name: Build all Windows apps
       run: |
         cd BuildAndRelease/WinBuilds

--- a/BuildAndRelease/check_spec_completeness.py
+++ b/BuildAndRelease/check_spec_completeness.py
@@ -1,117 +1,335 @@
 #!/usr/bin/env python3
 """
-PyInstaller Spec File Completeness Check
+PyInstaller spec completeness check.
 
-Verifies that all Python modules in scripts/ are properly included in the
-PyInstaller spec file (final_working.spec). This catches the common mistake
-of adding a new module but forgetting to update the spec file.
+Catches the failure mode CLAUDE.md documents and this repo keeps hitting: a
+first-party module is reachable only through a lazy import, the spec never
+names it, and it fails solely in the frozen executable -- the hardest place to
+notice it.
 
-Run this before building to ensure frozen executable won't have missing imports.
+    ModuleNotFoundError: No module named 'idt_core.chat.engine'
+
+What is reported, and what is not
+---------------------------------
+Only imports that are **lazy and unguarded**:
+
+* **lazy** -- inside a function body. PyInstaller walks module-level imports
+  itself and bundles what it finds; it cannot see one that runs only when the
+  function is called. Those are what ``hiddenimports`` exists for.
+* **unguarded** -- not inside a ``try``. An import wrapped in try/except is
+  already declared optional by the code that handles its absence. Demanding a
+  hidden import for it would be wrong: ``idt_core/chat/mlx.py`` imports
+  ``imagedescriber.ai_providers`` that way precisely because the chat app does
+  not bundle it.
+
+An earlier draft of this rewrite flagged every transitive module-level import
+and produced pages of findings that were all fine. That is worth stating,
+because a checker nobody reads is exactly how the previous one stayed dead.
+
+What it replaced
+----------------
+The previous version checked that every ``.py`` file in ``scripts/`` appeared
+in ``final_working.spec``. Both had ceased to exist: the spec was renamed, and
+``scripts/`` was emptied of Python in 2a32e6d and now holds only JSON. It
+exited immediately with "Spec file not found". Repointing it alone would have
+been worse than leaving it broken -- it would have iterated over zero modules
+and reported success every time.
+
+Usage
+-----
+    python BuildAndRelease/check_spec_completeness.py
+
+Exit status is 0 when every spec is complete, 1 otherwise, so it can gate a
+build.
 """
+from __future__ import annotations
+
+import ast
 import sys
+from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Dict, List, Optional, Set, Tuple
+
+ROOT = Path(__file__).resolve().parent.parent
+
+#: Import roots that live in this repo. Third-party packages are PyInstaller's
+#: problem, not ours -- its hooks handle those.
+FIRST_PARTY = ("idt_core", "cli", "shared", "imagedescriber", "chatapp")
 
 
-def find_python_modules(directory):
-    """Find all .py files in a directory"""
-    py_files = list(directory.glob('*.py'))
-    # Return stems (filename without .py)
-    return {f.stem for f in py_files if f.stem != '__init__'}
+@dataclass
+class App:
+    name: str
+    spec: Path
+    entry: Path
+    #: Directories whose modules may be imported "flat" -- ``from data_models
+    #: import ...`` rather than ``from imagedescriber.data_models import ...``.
+    #: Mandatory in frozen mode, which is why the specs list both spellings.
+    flat_dirs: List[Path] = field(default_factory=list)
 
 
-def check_spec_file(spec_path, modules_to_check, directory_name):
-    """Check if all modules are referenced in spec file"""
-    spec_text = spec_path.read_text(encoding='utf-8')
-    
-    missing_from_datas = []
-    missing_from_hiddenimports = []
-    
-    for module in sorted(modules_to_check):
-        # Check datas section (looks for pattern like: ('../scripts/module.py', 'scripts'))
-        if f"/{module}.py" not in spec_text:
-            missing_from_datas.append(module)
-        
-        # Check hiddenimports section (looks for pattern like: 'scripts.module')
-        if f"{directory_name}.{module}" not in spec_text:
-            missing_from_hiddenimports.append(module)
-    
-    return missing_from_datas, missing_from_hiddenimports
+APPS = [
+    App("idt (CLI)", ROOT / "idt" / "idt.spec", ROOT / "cli" / "main.py"),
+    App(
+        "ImageDescriber",
+        ROOT / "imagedescriber" / "imagedescriber_wx.spec",
+        ROOT / "imagedescriber" / "imagedescriber_wx.py",
+        flat_dirs=[ROOT / "imagedescriber"],
+    ),
+    App(
+        "IDT Chat",
+        ROOT / "chatapp" / "chatapp.spec",
+        ROOT / "chatapp" / "chat_app_wx.py",
+        flat_dirs=[ROOT / "chatapp"],
+    ),
+]
 
 
-def main():
-    """Run completeness check"""
-    print("=" * 70)
-    print("PYINSTALLER SPEC FILE COMPLETENESS CHECK")
-    print("=" * 70)
+# ---------------------------------------------------------------------------
+# Import discovery
+# ---------------------------------------------------------------------------
+
+#: (dotted name, is_lazy, is_guarded)
+Found = Tuple[str, bool, bool]
+
+
+class _ImportScanner(ast.NodeVisitor):
+    """Records every import with enough context to judge whether it matters."""
+
+    def __init__(self, module_package: str):
+        self.module_package = module_package
+        self.found: List[Found] = []
+        self._in_function = 0
+        self._in_try = 0
+
+    def visit_FunctionDef(self, node):  # noqa: N802 - ast API naming
+        self._in_function += 1
+        self.generic_visit(node)
+        self._in_function -= 1
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_Try(self, node):  # noqa: N802 - ast API naming
+        self._in_try += 1
+        self.generic_visit(node)
+        self._in_try -= 1
+
+    def _record(self, dotted: str) -> None:
+        if dotted:
+            self.found.append((dotted, self._in_function > 0, self._in_try > 0))
+
+    def visit_Import(self, node):  # noqa: N802 - ast API naming
+        for alias in node.names:
+            self._record(alias.name)
+
+    def visit_ImportFrom(self, node):  # noqa: N802 - ast API naming
+        if node.level:
+            bits = self.module_package.split(".")
+            if node.level > 1:
+                bits = bits[: -(node.level - 1)] or bits
+            base = ".".join(bits)
+            self._record(f"{base}.{node.module}" if node.module else base)
+        else:
+            self._record(node.module or "")
+
+
+def _module_path(dotted: str) -> Optional[Path]:
+    """Locate a first-party module on disk, whether package or single file."""
+    parts = dotted.split(".")
+    as_module = ROOT.joinpath(*parts).with_suffix(".py")
+    if as_module.is_file():
+        return as_module
+    as_package = ROOT.joinpath(*parts, "__init__.py")
+    if as_package.is_file():
+        return as_package
+    return None
+
+
+def _resolve_flat(name: str, flat_dirs: List[Path]) -> Optional[str]:
+    """Map a flat import to its dotted form: data_models -> imagedescriber.data_models."""
+    for directory in flat_dirs:
+        if (directory / f"{name}.py").is_file():
+            return f"{directory.name}.{name}"
+    return None
+
+
+def _normalise(dotted: str, flat_dirs: List[Path]) -> Optional[str]:
+    """Return the first-party dotted name, or None if this is third-party."""
+    if not dotted:
+        return None
+    root = dotted.split(".")[0]
+    if root in FIRST_PARTY:
+        return dotted
+    return _resolve_flat(root, flat_dirs)
+
+
+def _scan(path: Path, flat_dirs: List[Path]) -> List[Found]:
+    """First-party imports in one file, each tagged lazy/guarded."""
+    try:
+        source = path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(path))
+    except (OSError, SyntaxError):
+        return []
+
+    try:
+        package = path.parent.relative_to(ROOT).as_posix().replace("/", ".")
+    except ValueError:
+        package = ""
+
+    scanner = _ImportScanner(package)
+    scanner.visit(tree)
+
+    results: List[Found] = []
+    for dotted, lazy, guarded in scanner.found:
+        normalised = _normalise(dotted, flat_dirs)
+        if normalised:
+            results.append((normalised, lazy, guarded))
+    return results
+
+
+def walk_imports(app: App) -> Tuple[Set[str], Set[str]]:
+    """Traverse the import graph from the entry point.
+
+    Returns ``(all_modules, must_declare)``. A module lands in must_declare
+    only when *every* route to it is lazy and unguarded. If anything in the
+    graph imports it at module level, PyInstaller's static analysis finds it
+    there and bundles it, so a hidden import would be redundant.
+
+    That distinction is what makes this usable. Without it the check reported
+    ``idt_core.scanner`` as missing from the chat app, when
+    ``idt_core/__init__.py`` imports it at module scope on line 9 and it is
+    bundled either way.
+    """
+    everything: Set[str] = set()
+    lazy_unguarded: Set[str] = set()
+    statically_reachable: Set[str] = set()
+    queue: List[Path] = [app.entry]
+    visited: Set[Path] = set()
+
+    while queue:
+        current = queue.pop()
+        if current in visited or not current.is_file():
+            continue
+        visited.add(current)
+
+        for dotted, lazy, guarded in _scan(current, app.flat_dirs):
+            everything.add(dotted)
+            if lazy and not guarded:
+                lazy_unguarded.add(dotted)
+            elif not lazy:
+                statically_reachable.add(dotted)
+            target = _module_path(dotted)
+            if target is not None:
+                queue.append(target)
+
+    return everything, lazy_unguarded - statically_reachable
+
+
+# ---------------------------------------------------------------------------
+# Spec inspection
+# ---------------------------------------------------------------------------
+
+
+def spec_declares(spec_text: str, dotted: str, flat_dirs: List[Path]) -> bool:
+    """True if the spec names this module, in a spelling that actually applies.
+
+    The bare name counts only for modules that are genuinely flat-importable --
+    those living in one of the app's own directories, where the specs list both
+    ``'imagedescriber.data_models'`` and ``'data_models'`` because frozen mode
+    needs the flat form.
+
+    Accepting the bare name unconditionally made this check useless: deleting
+    ``'idt_core.providers.ollama'`` from a spec still passed, because the
+    unrelated third-party ``'ollama'`` entry matched its last component. A
+    checker that cannot fail is the failure mode this file was rewritten to
+    escape, so the short form is only honoured where it is real.
+    """
+    for quote in ("'", '"'):
+        if f"{quote}{dotted}{quote}" in spec_text:
+            return True
+
+    short = dotted.split(".")[-1]
+    if _resolve_flat(short, flat_dirs) == dotted:
+        for quote in ("'", '"'):
+            if f"{quote}{short}{quote}" in spec_text:
+                return True
+    return False
+
+
+def check(app: App) -> Tuple[List[str], int]:
+    """Return (missing hidden imports, total first-party modules seen)."""
+    if not app.spec.is_file():
+        raise FileNotFoundError(f"spec not found: {app.spec}")
+    if not app.entry.is_file():
+        raise FileNotFoundError(f"entry point not found: {app.entry}")
+
+    spec_text = app.spec.read_text(encoding="utf-8")
+    everything, must_declare = walk_imports(app)
+    missing = sorted(
+        d for d in must_declare
+        if not spec_declares(spec_text, d, app.flat_dirs)
+    )
+    return missing, len(everything)
+
+
+def main() -> int:
+    print("=" * 72)
+    print("PYINSTALLER SPEC COMPLETENESS CHECK")
+    print("=" * 72)
     print()
-    
-    # Find spec file and scripts directory
-    build_dir = Path(__file__).parent
-    spec_file = build_dir / 'final_working.spec'
-    scripts_dir = build_dir.parent / 'scripts'
-    
-    if not spec_file.exists():
-        print(f"[FAIL] ERROR: Spec file not found at {spec_file}")
-        return 1
-    
-    if not scripts_dir.exists():
-        print(f"[FAIL] ERROR: Scripts directory not found at {scripts_dir}")
-        return 1
-    
-    print(f"Spec file: {spec_file.name}")
-    print(f"Checking: {scripts_dir}")
-    print()
-    
-    # Find all Python modules
-    modules = find_python_modules(scripts_dir)
-    print(f"Found {len(modules)} Python modules in scripts/")
-    
-    # Check spec file
-    missing_datas, missing_imports = check_spec_file(spec_file, modules, 'scripts')
-    
-    # Report results
-    if not missing_datas and not missing_imports:
+
+    failures: Dict[str, List[str]] = {}
+    broken = False
+
+    for app in APPS:
+        rel_spec = app.spec.relative_to(ROOT).as_posix()
+        try:
+            missing, total = check(app)
+        except FileNotFoundError as exc:
+            print(f"[FAIL] {app.name}: {exc}")
+            broken = True
+            continue
+
+        if missing:
+            print(f"[FAIL] {app.name}: {len(missing)} lazy import(s) not declared "
+                  f"in {rel_spec}")
+            failures[app.name] = missing
+        else:
+            print(f"[ OK ] {app.name}: {total} first-party modules reached, "
+                  f"every lazy import declared in {rel_spec}")
+
+    if not failures and not broken:
         print()
-        print("[SUCCESS] ALL MODULES ARE PROPERLY INCLUDED IN SPEC FILE")
+        print("All specs complete.")
         print()
         return 0
-    
-    # Show what's missing
-    print()
-    print("[FAIL] MISSING MODULES DETECTED")
-    print()
-    
-    if missing_datas:
-        print("Missing from 'datas' section:")
-        print("-" * 70)
-        print("Add these lines to the datas list in final_working.spec:")
+
+    if failures:
         print()
-        for module in sorted(missing_datas):
-            print(f"        ('../scripts/{module}.py', 'scripts'),")
+        print("=" * 72)
+        print("MISSING HIDDEN IMPORTS")
+        print("=" * 72)
+        for name, missing in failures.items():
+            app = next(a for a in APPS if a.name == name)
+            print()
+            print(f"{name} -- add to hiddenimports in "
+                  f"{app.spec.relative_to(ROOT).as_posix()}:")
+            print()
+            for dotted in missing:
+                print(f"        '{dotted}',")
+
         print()
-    
-    if missing_imports:
-        print("Missing from 'hiddenimports' section:")
-        print("-" * 70)
-        print("Add these lines to the hiddenimports list in final_working.spec:")
+        print("-" * 72)
+        print("These are imported inside a function, so PyInstaller's static")
+        print("analysis cannot see them. They import fine in development and")
+        print("fail only in the frozen build. If one is genuinely optional,")
+        print("wrap it in try/except and this check will stop asking.")
+        print("See CLAUDE.md, 'PyInstaller Frozen Mode Imports'.")
+        print("=" * 72)
         print()
-        for module in sorted(missing_imports):
-            print(f"        'scripts.{module}',")
-        print()
-    
-    print("=" * 70)
-    print("WHY THIS MATTERS:")
-    print("-" * 70)
-    print("Missing modules will cause import errors in the frozen executable.")
-    print("The executable will build successfully but fail at runtime with:")
-    print("  ModuleNotFoundError or ImportError")
-    print()
-    print("Fix the spec file before building to avoid deployment issues.")
-    print("=" * 70)
-    print()
-    
+
     return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     sys.exit(main())

--- a/pytest_tests/unit/test_spec_completeness_checker.py
+++ b/pytest_tests/unit/test_spec_completeness_checker.py
@@ -1,0 +1,207 @@
+"""The spec checker itself, and the two ways it can quietly stop working.
+
+BuildAndRelease/check_spec_completeness.py guards a failure this repo keeps
+hitting: a first-party module reachable only through a lazy import, absent from
+a PyInstaller spec, working perfectly in development and failing solely in the
+frozen build.
+
+It had been dead for months before this file existed. It pointed at
+``final_working.spec``, renamed long ago, and scanned ``scripts/`` for Python
+that had been removed in 2a32e6d -- so it exited on a missing file, and had it
+merely been repointed it would have iterated over zero modules and reported
+success forever.
+
+That is the shape of the risk, so the tests are about the checker's *ability to
+fail*, not only its verdict:
+
+* :func:`test_it_catches_a_removed_hidden_import` deletes a real entry from a
+  real spec in a temporary copy and demands a non-zero exit. Without it, the
+  lenient name matching that shipped in the first draft -- where the unrelated
+  third-party ``'ollama'`` entry satisfied ``idt_core.providers.ollama`` --
+  would have gone unnoticed and the checker would have been decorative.
+* :func:`test_it_examines_a_meaningful_number_of_modules` fails if the walk
+  collapses to nothing, which is exactly how the old one would have "passed".
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+_CHECKER = _ROOT / "BuildAndRelease" / "check_spec_completeness.py"
+
+sys.path.insert(0, str(_CHECKER.parent))
+import check_spec_completeness as checker  # noqa: E402
+
+
+def _run(cwd=None):
+    return subprocess.run(
+        [sys.executable, str(_CHECKER)],
+        cwd=str(cwd or _ROOT),
+        capture_output=True, text=True, errors="replace", timeout=120,
+    )
+
+
+# ---------------------------------------------------------------------------
+# It runs, and it is not vacuous
+# ---------------------------------------------------------------------------
+
+def test_the_checker_exists_and_runs():
+    """It was hard-coded to a file that no longer existed and exited at once."""
+    proc = _run()
+    assert "Spec file not found" not in proc.stdout
+    assert "PYINSTALLER SPEC COMPLETENESS CHECK" in proc.stdout
+
+
+def test_specs_are_currently_complete():
+    proc = _run()
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "All specs complete." in proc.stdout
+
+
+@pytest.mark.parametrize("app", checker.APPS, ids=lambda a: a.name)
+def test_every_app_has_a_real_spec_and_entry_point(app):
+    assert app.spec.is_file(), f"{app.name}: spec missing at {app.spec}"
+    assert app.entry.is_file(), f"{app.name}: entry point missing at {app.entry}"
+
+
+@pytest.mark.parametrize("app", checker.APPS, ids=lambda a: a.name)
+def test_it_examines_a_meaningful_number_of_modules(app):
+    """A walk that finds nothing would report success on any spec at all.
+
+    This is the precise way the previous checker would have failed after a
+    repoint: zero modules to iterate, so the loop body never ran.
+    """
+    everything, _ = checker.walk_imports(app)
+    assert len(everything) >= 10, (
+        f"{app.name}: only {len(everything)} first-party modules reached -- "
+        "the import walk has probably broken"
+    )
+
+
+def test_all_three_apps_are_covered():
+    names = {app.spec.name for app in checker.APPS}
+    assert names == {"idt.spec", "imagedescriber_wx.spec", "chatapp.spec"}
+
+
+# ---------------------------------------------------------------------------
+# It can actually fail
+# ---------------------------------------------------------------------------
+
+def _lazy_declared_entry(app):
+    """A module the spec declares *and* that is only reached lazily."""
+    _, must_declare = checker.walk_imports(app)
+    spec_text = app.spec.read_text(encoding="utf-8")
+    for dotted in sorted(must_declare):
+        if f"'{dotted}'" in spec_text:
+            return dotted
+    return None
+
+
+def test_it_catches_a_removed_hidden_import(tmp_path):
+    """Delete a real entry from a copy of the tree; the check must fail.
+
+    Copies only what the checker reads, so the working tree is never touched.
+    """
+    app = next(a for a in checker.APPS if a.spec.name == "chatapp.spec")
+    victim = _lazy_declared_entry(app)
+    assert victim, "no lazily-imported declared module found to remove"
+
+    import shutil
+
+    sandbox = tmp_path / "repo"
+    for part in ("BuildAndRelease", "chatapp", "idt_core", "shared", "cli",
+                 "imagedescriber", "idt"):
+        source = _ROOT / part
+        if source.is_dir():
+            shutil.copytree(source, sandbox / part,
+                            ignore=shutil.ignore_patterns(
+                                "__pycache__", "dist", "build", ".venv",
+                                ".winenv", "*.exe", "*.app"))
+
+    spec = sandbox / "chatapp" / "chatapp.spec"
+    text = spec.read_text(encoding="utf-8")
+    trimmed = re.sub(rf"^\s*'{re.escape(victim)}',\n", "", text, flags=re.MULTILINE)
+    assert trimmed != text, f"could not remove {victim} from the spec copy"
+    spec.write_text(trimmed, encoding="utf-8")
+
+    proc = subprocess.run(
+        [sys.executable, str(sandbox / "BuildAndRelease" / "check_spec_completeness.py")],
+        capture_output=True, text=True, errors="replace", timeout=120,
+    )
+
+    assert proc.returncode == 1, (
+        f"removing {victim} from chatapp.spec did not fail the check:\n"
+        + proc.stdout
+    )
+    assert victim in proc.stdout, "the report should name the missing module"
+
+
+def test_an_unrelated_entry_does_not_satisfy_a_dotted_name():
+    """'ollama' must not count as declaring 'idt_core.providers.ollama'.
+
+    The first draft accepted any trailing component, so a spec listing the
+    third-party SDK appeared to declare our module of the same leaf name. That
+    made the check unable to fail on the very omission it exists to catch.
+    """
+    spec_text = "hiddenimports=['ollama', 'anthropic']"
+    assert not checker.spec_declares(spec_text, "idt_core.providers.ollama", [])
+
+
+def test_the_flat_spelling_is_still_accepted():
+    """imagedescriber imports flat ('from data_models import ...') in frozen mode."""
+    app = next(a for a in checker.APPS if a.spec.name == "imagedescriber_wx.spec")
+    spec_text = "hiddenimports=['data_models']"
+    assert checker.spec_declares(
+        spec_text, "imagedescriber.data_models", app.flat_dirs)
+
+
+# ---------------------------------------------------------------------------
+# Classification rules
+# ---------------------------------------------------------------------------
+
+def test_a_guarded_optional_import_is_not_demanded(tmp_path):
+    """try/except means the code already handles absence.
+
+    idt_core/chat/mlx.py imports imagedescriber.ai_providers exactly this way,
+    because the chat app deliberately does not bundle it.
+    """
+    module = tmp_path / "sample.py"
+    module.write_text(
+        "def go():\n"
+        "    try:\n"
+        "        from idt_core.chat import engine\n"
+        "    except ImportError:\n"
+        "        engine = None\n",
+        encoding="utf-8",
+    )
+    found = checker._scan(module, [])
+    assert found, "the import should still be discovered"
+    assert all(guarded for _, _, guarded in found)
+
+
+def test_a_module_level_import_is_not_demanded(tmp_path):
+    """PyInstaller finds those itself; demanding them is noise."""
+    module = tmp_path / "sample.py"
+    module.write_text("from idt_core.chat import engine\n", encoding="utf-8")
+    found = checker._scan(module, [])
+    assert found
+    assert all(not lazy for _, lazy, _ in found)
+
+
+def test_a_lazy_unguarded_import_is_flagged(tmp_path):
+    module = tmp_path / "sample.py"
+    module.write_text(
+        "def go():\n    from idt_core.chat import engine\n", encoding="utf-8")
+    found = checker._scan(module, [])
+    assert ("idt_core.chat", True, False) in found
+
+
+def test_third_party_imports_are_ignored(tmp_path):
+    module = tmp_path / "sample.py"
+    module.write_text(
+        "import wx\ndef go():\n    import anthropic\n", encoding="utf-8")
+    assert checker._scan(module, []) == []


### PR DESCRIPTION
`BuildAndRelease/check_spec_completeness.py` had been dead for months. It pointed at `final_working.spec`, renamed long ago, and scanned `scripts/` for Python removed in `2a32e6d`, so it exited immediately with "Spec file not found".

**Repointing it was not enough.** `scripts/` holds only JSON now, so the module loop would have run zero times and reported success on every spec, forever — worse than an error, because it looks like it works. Same shape as the attachment bug earlier in this series: a stub returning a plausible answer.

## What it checks now

Walks the real import graph from each app's entry point and reports first-party modules the spec never names — but only those reached by a **lazy, unguarded** import:

| | |
|---|---|
| **lazy** | inside a function, so PyInstaller's static analysis cannot see it. Module-level imports it follows itself. |
| **unguarded** | not inside `try/except`. A guarded import is already declared optional by the code handling its absence — `idt_core/chat/mlx.py` imports `imagedescriber.ai_providers` that way precisely because the chat app does not bundle it. |
| **and reachable no other way** | if anything imports it at module level, PyInstaller finds it there and a hidden import is redundant. |

Two drafts were discarded getting here, and both failure modes are worth knowing:

1. The first flagged every transitive module-level import — pages of findings, all fine. Noise is how the last checker got ignored.
2. The second **still passed when a real entry was deleted**, because it accepted any trailing component: the unrelated third-party `'ollama'` entry satisfied `idt_core.providers.ollama`.

## Proof it can fail

`test_it_catches_a_removed_hidden_import` copies the tree, deletes a genuine entry from `chatapp.spec`, and requires a non-zero exit. Without it, draft two would have shipped looking healthy.

`test_it_examines_a_meaningful_number_of_modules` fails if the walk collapses below ten modules — exactly how the old checker would have "passed" after a repoint.

Plus unit tests for each classification rule: guarded, module-level, lazy-unguarded, third-party.

## Run in CI

Added to both build workflows, before the build. It was not wired into anything, which is why nobody noticed it had stopped working. It costs seconds; the failure it finds costs a full packaging cycle.

## Result

All three specs pass — `idt` (36 modules reached), ImageDescriber (47), IDT Chat (35). 1236 tests, all 23 coverage floors met.