### PR TITLE
Fix ten post-merge review findings from PR #266

### DIFF
--- a/chatapp/chat_app_wx.py
+++ b/chatapp/chat_app_wx.py
@@ -234,14 +234,12 @@ class ProviderDialog(wx.Dialog):
         models = []
         try:
             if provider == "ollama":
-                from idt_core.providers.ollama import OllamaProvider, DEFAULT_MODEL
-
-                # Chat listing, not the describe listing: chat needs the
-                # `completion` capability, and filtering on vision here hid
-                # every text-only model — often the best chat models installed.
-                models = OllamaProvider(model=DEFAULT_MODEL).list_chat_models()
-                if not models:
-                    self.status.SetLabel("No Ollama models found. Is Ollama running?")
+                # Off the UI thread: listing asks /api/show once per installed
+                # model, so with 20-30 models pulled this froze the window for
+                # seconds — and far longer against a remote host or a stopped
+                # daemon, where every probe waits out its own timeout.
+                self._start_ollama_listing()
+                return
             elif provider == "claude":
                 from idt_core.providers.claude import (
                     CLAUDE_MODELS,
@@ -267,6 +265,52 @@ class ProviderDialog(wx.Dialog):
         if requires_api_key(provider) and not resolve_api_key(provider):
             self.status.SetLabel(missing_key_message(provider))
 
+        self._select_model(self._initial_model)
+
+    def _start_ollama_listing(self):
+        """List Ollama chat models on a worker thread, fill the picker after.
+
+        The generation token guards two races: the user switching provider
+        while a listing is in flight (a late result must not repopulate the
+        picker for a different provider), and the dialog being closed before
+        the thread finishes.
+        """
+        import threading
+
+        self._load_token = getattr(self, "_load_token", 0) + 1
+        token = self._load_token
+        self.status.SetLabel("Looking for Ollama models…")
+
+        def work():
+            try:
+                from idt_core.providers.ollama import OllamaProvider, DEFAULT_MODEL
+
+                # Chat listing, not the describe listing: chat needs the
+                # `completion` capability, and filtering on vision here hid
+                # every text-only model — often the best chat models installed.
+                found = OllamaProvider(model=DEFAULT_MODEL).list_chat_models()
+                error = ""
+            except Exception as exc:                        # noqa: BLE001
+                found, error = [], str(exc)
+            wx.CallAfter(self._finish_ollama_listing, token, found, error)
+
+        threading.Thread(target=work, daemon=True).start()
+
+    def _finish_ollama_listing(self, token, models, error):
+        if token != getattr(self, "_load_token", 0):
+            return                      # superseded by a newer request
+        if not self:
+            return                      # dialog closed while we were listing
+
+        for model_id in models:
+            self.model_choice.Append(model_id, model_id)
+
+        if error:
+            self.status.SetLabel(f"Could not list models: {error}")
+        elif not models:
+            self.status.SetLabel("No Ollama models found. Is Ollama running?")
+        else:
+            self.status.SetLabel("")
         self._select_model(self._initial_model)
 
     def _select_model(self, wanted: str):

--- a/docs/WorkTracking/2026-08-15-session-summary.md
+++ b/docs/WorkTracking/2026-08-15-session-summary.md
@@ -1,0 +1,166 @@
+# Session Summary — 2026-08-15
+
+## Goal
+
+Re-review PR #266 after it merged, and fix what the first pass missed.
+
+The first review (posted 01:13 UTC, eight findings) was acted on in `55cb3de`
+and merged as `4a13640`. This session ran a wider multi-angle pass over the
+merged result, found ten further issues, verified each against `main`, and
+fixed them.
+
+## What the second pass found
+
+Eight independent finder angles (line-by-line, removed-behaviour, cross-file,
+reuse, simplification, efficiency, altitude, CLAUDE.md conventions) produced
+~40 raw candidates. Roughly a quarter did not survive verification — see
+"Rejected" below, which is the more useful half of this document.
+
+### Accessibility
+
+1. **Read-aloud spoke at maximum rate by default.** `RATE_PRESETS` has no
+   `"auto"` key and `"auto"` is the default engine, so `resolved_rate()`
+   returned `None` for *every* preset including "slow". `speak-engine.ps1`
+   then fell through to `$oneCoreRate = 6.0` — the top of the OneCore scale,
+   as `speak-voices.ps1` documents. The Settings dialog compounded it:
+   `SpeechOption.has_rate` is False for `auto`, so the rate control is
+   *disabled* on exactly the configuration that needed it.
+   **Fixed in the router**, not in Python: an unset rate now means the middle
+   of each scale (OneCore 3.0, SAPI 0). The design principle that screen-reader
+   routes never receive a rate is deliberately preserved — that is why `auto`
+   resolves to `None` in the first place, and it is correct.
+
+2. **`strip_for_speech` mangled snake_case.** `_EMPHASIS` treated every
+   underscore as markdown emphasis: `MAX_TOOL_ROUNDS` → "MAXTOOLROUNDS",
+   `some_var_name` → "somevarname". For a developer's chat client the listener
+   heard identifiers that do not exist. Underscore emphasis now requires word
+   boundaries; `*` handling is unchanged.
+
+### Correctness
+
+3. **Saving a key broke Generate Video Description.** Configure Settings writes
+   to the credential store and purges the plaintext config copy, but
+   `get_api_key_for_provider` still read only `self.config`, so the video guard
+   aborted and pointed the user at the screen where they had just set the key.
+   Now consults `idt_core.keys.resolve_api_key` first.
+   `tools/check_api_usage.py:140` shares the pattern and is **not** fixed here.
+
+4. **Context probes ignored `OLLAMA_HOST`.** `model_context_length` defaulted
+   `host` to localhost and built `ollama.Client(host=...)` explicitly, which
+   defeats the SDK's env fallback; two of three callers passed no host at all.
+   A remote-Ollama user chatted fine while every probe hit localhost, failed,
+   and budgeted a 262k model as 32k. `host` now defaults to `None` (SDK/env
+   decides) and is part of the cache key.
+
+5. **`num_ctx` could request an unallocatable KV cache.** Discovery reports
+   1,048,576 for nemotron; the budgeter fills that window and `_num_ctx` passed
+   the figure straight to the server. Added a 131,072 ceiling, overridable via
+   `IDT_MAX_NUM_CTX`. A smaller trained window still wins.
+
+6. **The MLX formatter silently dropped text attachments.** Every other
+   formatter moved to `merge_text_attachments`; MLX still read `msg.content`.
+   Conversations are provider-agnostic, so a `.txt` attached under Ollama
+   vanished when the history replayed through MLX — no error, and the model
+   answered about a file it was never shown.
+
+7. **`_store_key` wrote into a throwaway dict.**
+   `configs.get("image_describer", {})` returns a fresh dict when the section
+   is absent, so on a platform with no credential store the key went into a
+   temporary, was reported as saved, and was lost. Now `setdefault`, in both
+   `_store_key` and `_purge_config_key`.
+
+8. **`load_api_keys` hid non-canonical keys.** Listing only the three known
+   providers made a key written by an older build invisible *and* undeletable
+   while it sat in plaintext. Unrecognised entries now get their own row, and
+   `_purge_config_key`'s fallback is lowercased so such a row can be deleted.
+
+### Performance
+
+9. **Two or three blocking `/api/show` round trips per turn.** Capabilities and
+   context length were probed separately from the same endpoint, and neither
+   cache stored failures — so an unreachable daemon was re-probed on every
+   turn, each attempt waiting out its own timeout. Collapsed into one cached,
+   host-keyed `_show()`. Failures are cached for 30 s: long enough that a turn
+   costs one attempt, short enough that a daemon started later is still picked
+   up. This replaces `_VISION_CACHE` / `_CAPS_CACHE` / `_CONTEXT_CACHE`.
+
+10. **The model picker blocked the UI thread** on one `/api/show` per installed
+    model. Moved to a worker thread, with a generation token so a late result
+    cannot repopulate the picker after the user has switched provider.
+
+Also fixed: `_script_dir()`'s frozen fallback was dead code — `Path("")` is
+`Path(".")`, which is truthy, so a missing `_MEIPASS` resolved the speech
+scripts against the working directory. And `_win_credential` took a `target`
+argument it never read.
+
+## Rejected during verification
+
+Worth recording, because these were confidently reported and are wrong:
+
+- **`_CONFIG_SPELLINGS` vs `_CONFIG_ALIASES` divergence leaves plaintext keys
+  behind.** Raised independently by two finder angles. It does not:
+  `_purge_config_key` lowercases every key before matching, so keys.py's
+  `"Claude"`/`"ANTHROPIC"` collapse onto entries the dialog already has, and
+  the dialog's set is a superset.
+- **`--no-think` can fail a turn on non-thinking models.** Reported in the
+  first pass. Tested against a live daemon with `moondream:latest`
+  (capabilities: `completion, vision`): `think: false` returns no error. The
+  PR comment was deleted.
+- **`ai_providers.py`'s retained private lookups let a deleted key keep
+  working from stale config.** `resolve_api_key` already checks the config and
+  covers a superset of what `_load_api_key_from_config` reads, so those
+  fallbacks are unreachable dead code — a tidiness point, not a key leak.
+- **Full message text in `wx.ListBox` renders newlines as glyphs.** Raised by
+  two angles. `_line_for` already does `" ".join(content.split())`, which
+  collapses newlines.
+
+## Regression caught by live testing
+
+The first cut of the unified `_show()` triggered the raw-REST fallback only
+when the *entire* SDK response was empty. Real servers return `capabilities`
+while dropping `model_info`, so the fallback never fired and context discovery
+silently returned `None` for gemma4 — a model that reports 262,144 over REST.
+The trigger is now that specific field. Unit tests passed either way; only the
+live probe caught it, which is the argument for running one.
+
+## Files changed
+
+`idt_core/providers/ollama.py` (probe rework), `idt_core/chat/providers.py`
+(num_ctx ceiling, host passthrough), `idt_core/chat/mlx.py`, `idt_core/keys.py`,
+`shared/speech_engine.py`, `shared/speech/speak-engine.ps1`,
+`chatapp/chat_app_wx.py`, `imagedescriber/configure_dialog.py`,
+`imagedescriber/imagedescriber_wx.py`.
+
+Tests: `pytest_tests/unit/test_post_266_review_fixes.py` (new, 19 tests), plus
+updates to `test_ollama_context_length.py` and `test_ollama_vision_filter.py`
+for the merged cache.
+
+`test_failure_is_not_cached` was rewritten as
+`test_failure_is_cached_only_briefly`. Its original intent ("Ollama may simply
+not be running yet; retry next call") is preserved by the TTL — the change is
+that a *single turn* no longer pays repeated timeouts.
+
+## Test results
+
+- Unit suite: **1401 passed, 16 skipped**.
+- Live against local Ollama: context discovery matches the figures recorded in
+  #266 (gemma4 262,144; nemotron 1,048,576; moondream 2,048) with **one** round
+  trip per model instead of three; second and third probes served from cache in
+  ~0.00 s.
+- Live CLI turn (`nemotron-3.5-lightning`): clean `PELICAN` on stdout,
+  `[thinking…]` on stderr, exit 0.
+- `num_ctx`: 4,096 for a short chat, capped at 131,072 for a 4 MB prompt
+  against the 1M-context model.
+- `speak-engine.ps1` parses (PowerShell AST parser).
+
+## NOT tested
+
+- The wx dialogs interactively, including with a screen reader. The speech rate
+  fix was verified by reading the router's dispatch, not by listening.
+- The macOS speech routes, and the Keychain path.
+- MLX (Windows machine) — the text-attachment fix is covered by unit tests and
+  source inspection only.
+- The threaded model picker under a real provider switch mid-listing; the race
+  is guarded by a generation token and covered by reasoning, not a test.
+- `tools/check_api_usage.py`, which shares the config-only key-reading pattern
+  fixed in `imagedescriber_wx.py`.

--- a/idt_core/chat/mlx.py
+++ b/idt_core/chat/mlx.py
@@ -15,6 +15,7 @@ from typing import Iterator
 
 from ..providers.base import ChatDelta, ChatProvider, ChatRequest, ChatUsage, ChatYield
 from .messages import conversation_turns
+from .providers import merge_text_attachments
 
 __all__ = ["MLXChatProvider"]
 
@@ -110,17 +111,25 @@ class MLXChatProvider(ChatProvider):
                 )
             image_assigned = False
             for msg in conversation_turns(request.messages):
+                # Text attachments are inlined here exactly as every other
+                # formatter does it. MLX's registry entry accepts images only,
+                # so nothing text-shaped can be attached *while on MLX* — but
+                # conversations are provider-agnostic, and a history carrying a
+                # .txt attached under Ollama replays through here. Reading
+                # msg.content directly dropped the file contents silently, and
+                # the model answered about a file it had never been shown.
+                text = merge_text_attachments(msg)
                 if msg.role == "user" and not image_assigned and temp_jpeg:
                     hf_messages.append({
                         "role": "user",
                         "content": [
                             {"type": "image"},
-                            {"type": "text", "text": msg.content},
+                            {"type": "text", "text": text},
                         ],
                     })
                     image_assigned = True
                 else:
-                    hf_messages.append({"role": msg.role, "content": msg.content})
+                    hf_messages.append({"role": msg.role, "content": text})
 
             try:
                 prompt = processor.apply_chat_template(

--- a/idt_core/chat/providers.py
+++ b/idt_core/chat/providers.py
@@ -224,6 +224,28 @@ class OllamaChatProvider(ChatProvider):
     NUM_CTX_STEP = 2048
     #: Reply headroom when the caller did not set max_output_tokens.
     DEFAULT_REPLY_HEADROOM = 2048
+    #: Hard ceiling on what we will ask the server to allocate, regardless of
+    #: what the model was trained for. Discovery reports figures like 262,144
+    #: (gemma4) and 1,048,576 (nemotron); the budgeter will happily fill a
+    #: window that size, and num_ctx then asks Ollama for a KV cache to match
+    #: — far past the RAM/VRAM of the machines this runs on, which fails the
+    #: turn on model load or thrashes the box. Overridable via IDT_MAX_NUM_CTX
+    #: for people with the hardware to back it.
+    DEFAULT_NUM_CTX_CEILING = 131_072
+
+    @classmethod
+    def _num_ctx_ceiling(cls) -> int:
+        import os
+
+        raw = os.environ.get("IDT_MAX_NUM_CTX", "").strip()
+        if raw:
+            try:
+                value = int(raw)
+                if value > 0:
+                    return value
+            except ValueError:
+                pass
+        return cls.DEFAULT_NUM_CTX_CEILING
 
     def __init__(self, model: str, host: Optional[str] = None):
         self._model = model
@@ -263,12 +285,14 @@ class OllamaChatProvider(ChatProvider):
             from ..providers.ollama import model_context_length
 
             cap = model_context_length(
-                request.model or self._model,
-                **({"host": self._host} if self._host else {}),
+                request.model or self._model, host=self._host
             )
         except Exception:
             cap = None
-        return min(cap or self.FALLBACK_MAX_NUM_CTX, max(self.MIN_NUM_CTX, needed))
+        # Two ceilings, both of which must hold: what the model was trained for,
+        # and what we are willing to make the server allocate.
+        cap = min(cap or self.FALLBACK_MAX_NUM_CTX, self._num_ctx_ceiling())
+        return min(cap, max(self.MIN_NUM_CTX, needed))
 
     def _request_options(self, request: ChatRequest) -> dict:
         """The ``options`` dict for /api/chat.
@@ -337,8 +361,7 @@ class OllamaChatProvider(ChatProvider):
             from ..providers.ollama import model_capabilities
 
             caps = model_capabilities(
-                request.model or self._model,
-                **({"host": self._host} if self._host else {}),
+                request.model or self._model, host=self._host
             )
         except Exception:
             caps = None

--- a/idt_core/keys.py
+++ b/idt_core/keys.py
@@ -162,8 +162,13 @@ def credential_store_name() -> str:
     return ""
 
 
-def _win_credential(target: str):
-    """(advapi32, CREDENTIAL struct type) — shared by read/write/delete."""
+def _win_credential():
+    """(ctypes, advapi32, CREDENTIAL struct type) — shared by read/write/delete.
+
+    Takes no target: it only builds the struct type. It used to accept a
+    ``target`` it never read, which invited callers to assume the returned
+    struct was bound to that credential.
+    """
     import ctypes
     import ctypes.wintypes as wintypes
 
@@ -191,7 +196,7 @@ _CRED_PERSIST_LOCAL_MACHINE = 2
 
 
 def _win_read(name: str) -> Optional[str]:
-    ctypes, advapi, CREDENTIAL = _win_credential(name)
+    ctypes, advapi, CREDENTIAL = _win_credential()
     pointer = ctypes.POINTER(CREDENTIAL)()
     if not advapi.CredReadW(_cred_target(name), _CRED_TYPE_GENERIC, 0,
                             ctypes.byref(pointer)):
@@ -209,7 +214,7 @@ def _win_read(name: str) -> Optional[str]:
 
 
 def _win_write(name: str, secret: str) -> bool:
-    ctypes, advapi, CREDENTIAL = _win_credential(name)
+    ctypes, advapi, CREDENTIAL = _win_credential()
     blob = secret.encode("utf-16-le")
     buffer = ctypes.create_string_buffer(blob, len(blob))
 
@@ -224,7 +229,7 @@ def _win_write(name: str, secret: str) -> bool:
 
 
 def _win_delete(name: str) -> bool:
-    ctypes, advapi, _ = _win_credential(name)
+    ctypes, advapi, _ = _win_credential()
     return bool(advapi.CredDeleteW(_cred_target(name), _CRED_TYPE_GENERIC, 0))
 
 

--- a/idt_core/providers/ollama.py
+++ b/idt_core/providers/ollama.py
@@ -5,6 +5,8 @@ Connects to a running Ollama instance; default host is localhost:11434.
 from __future__ import annotations
 
 import base64
+import os
+import time
 from typing import Optional
 
 from .base import BaseProvider, DescriptionResult
@@ -18,20 +20,105 @@ except ImportError:
         DEFAULT_MODEL = "llama3.2-vision"                               # fallback
 DEFAULT_HOST = "http://localhost:11434"
 
-# model name -> True/False, or absent when we could not determine it.
-# /api/show is one request per model and pickers list ~20, so cache per process.
-_VISION_CACHE: dict[str, bool] = {}
+# (host, model) -> the /api/show payload, or None when the probe failed.
+#
+# ONE cache for one endpoint. Capabilities, context length and vision all come
+# from the same /api/show response, so probing them separately meant a single
+# chat turn issued two or three round trips for the same model before the first
+# token. Keyed by host as well as name: the same model name on a local and a
+# remote server is not the same model, and a cached answer from one must never
+# be served for the other.
+_SHOW_CACHE: dict[tuple[str, str], Optional[dict]] = {}
 
-# model name -> context length in tokens. Successful lookups only; a failed
-# probe is retried next call because Ollama may simply not be running yet.
-_CONTEXT_CACHE: dict[str, int] = {}
+# Failures are cached too, but only briefly. Not caching them at all meant an
+# unreachable daemon was re-probed on every single turn, each attempt waiting
+# out its own timeout; caching them forever would mean Ollama starting up later
+# in the session was never noticed. A short TTL gets both.
+_NEGATIVE_TTL_SECONDS = 30.0
+_NEGATIVE_AT: dict[tuple[str, str], float] = {}
 
-# model name -> lowercased capability list from /api/show. Successful lookups
-# only, same reasoning as _CONTEXT_CACHE.
-_CAPS_CACHE: dict[str, list] = {}
+
+def _resolve_host(host: Optional[str]) -> str:
+    """The Ollama base URL to talk to.
+
+    ``None`` means "whatever the SDK would use", i.e. ``OLLAMA_HOST`` when it is
+    set. Passing an explicit host and letting the raw-REST fallback default to
+    localhost is what made remote-Ollama users silently fall back to a 32k
+    context window while their chat turns went to the real server.
+    """
+    resolved = (host or os.environ.get("OLLAMA_HOST") or DEFAULT_HOST).strip()
+    if not resolved.startswith(("http://", "https://")):
+        resolved = f"http://{resolved}"
+    return resolved.rstrip("/")
 
 
-def model_capabilities(name: str, host: str = DEFAULT_HOST, client=None) -> Optional[list]:
+def _show(name: str, host: Optional[str] = None, client=None) -> Optional[dict]:
+    """The /api/show payload for ``name``, as a plain dict, or None.
+
+    Tries the SDK first, then raw REST, because the ``ollama`` package drops
+    ``model_info`` entirely in some released versions. Results are cached per
+    (host, model); failures are cached for ``_NEGATIVE_TTL_SECONDS``.
+    """
+    resolved = _resolve_host(host)
+    key = (resolved, name)
+    if key in _SHOW_CACHE:
+        payload = _SHOW_CACHE[key]
+        if payload is not None:
+            return payload
+        if time.monotonic() - _NEGATIVE_AT.get(key, 0.0) < _NEGATIVE_TTL_SECONDS:
+            return None
+        # TTL expired — fall through and probe again.
+
+    own_client = client is None
+    info = None
+    try:
+        if client is None:
+            import ollama
+            client = ollama.Client(host=resolved)
+        info = client.show(name)
+    except Exception:
+        info = None
+
+    def _field(key_name):
+        if info is None:
+            return None
+        value = getattr(info, key_name, None)
+        if value is None and isinstance(info, dict):
+            value = info.get(key_name)
+        return value
+
+    payload = {
+        "model_info": _field("model_info"),
+        "parameters": _field("parameters"),
+        "capabilities": _field("capabilities"),
+    }
+
+    # The SDK drops `model_info` entirely in some released versions while still
+    # returning `capabilities`, so the trigger is that specific field being
+    # absent — not the whole response being empty. Getting this wrong means
+    # context discovery silently returns None on exactly the servers the REST
+    # fallback was written for. An injected client is a test double or a shared
+    # listing client, so only a client we made talks to the real server.
+    if own_client and payload["model_info"] is None:
+        try:
+            raw = _show_via_rest(name, resolved)
+            for field in ("model_info", "parameters", "capabilities"):
+                if payload[field] is None:
+                    payload[field] = raw.get(field)
+        except Exception:
+            pass
+
+    if not any(v is not None for v in payload.values()):
+        _SHOW_CACHE[key] = None
+        _NEGATIVE_AT[key] = time.monotonic()
+        return None
+
+    _SHOW_CACHE[key] = payload
+    _NEGATIVE_AT.pop(key, None)
+    return payload
+
+
+def model_capabilities(name: str, host: Optional[str] = None, client=None) -> Optional[list]:
     """Lowercased capability list from /api/show, or None when unavailable.
 
     Current servers report from {completion, vision, tools, thinking, insert,
@@ -39,26 +126,16 @@ def model_capabilities(name: str, host: str = DEFAULT_HOST, client=None) -> Opti
     their own fail-open/fail-closed policy — that is why this returns None
     instead of [].
     """
-    if name in _CAPS_CACHE:
-        return _CAPS_CACHE[name]
-    try:
-        if client is None:
-            import ollama
-            client = ollama.Client(host=host.rstrip("/"))
-        info = client.show(name)
-        caps = getattr(info, "capabilities", None)
-        if caps is None and isinstance(info, dict):
-            caps = info.get("capabilities")
-    except Exception:
+    payload = _show(name, host=host, client=client)
+    if payload is None:
         return None
+    caps = payload.get("capabilities")
     if caps is None:
         return None
-    result = [str(c).lower() for c in caps]
-    _CAPS_CACHE[name] = result
-    return result
+    return [str(c).lower() for c in caps]
 
 
-def model_is_chat_capable(name: str, host: str = DEFAULT_HOST, client=None) -> bool:
+def model_is_chat_capable(name: str, host: Optional[str] = None, client=None) -> bool:
     """True when the model can hold a conversation (`completion` capability).
 
     Fails OPEN like :func:`model_has_vision`, and for the same reason: a
@@ -108,84 +185,37 @@ def _show_via_rest(name: str, host: str) -> dict:
         return json.loads(response.read().decode("utf-8"))
 
 
-def model_context_length(name: str, host: str = DEFAULT_HOST, client=None) -> Optional[int]:
+def model_context_length(name: str, host: Optional[str] = None, client=None) -> Optional[int]:
     """Context length Ollama reports for a model, or None when unavailable.
 
     Reads /api/show. Newer servers expose ``model_info`` with an
     architecture-prefixed key (``llama.context_length``); older ones only
     mention ``num_ctx`` in the ``parameters`` string. Both are tried, in that
-    order, first through the SDK and then over raw REST (see
-    :func:`_show_via_rest`). Shared by the chat token budgeter and
-    ImageDescriber's token gauge so there is one implementation of this
-    parsing.
+    order. Shared by the chat token budgeter and ImageDescriber's token gauge
+    so there is one implementation of this parsing.
     """
-    if name in _CONTEXT_CACHE:
-        return _CONTEXT_CACHE[name]
-
-    own_client = client is None
-    try:
-        if client is None:
-            import ollama
-            client = ollama.Client(host=host.rstrip("/"))
-        info = client.show(name)
-    except Exception:
+    payload = _show(name, host=host, client=client)
+    if payload is None:
         return None
-
-    def _field(key):
-        value = getattr(info, key, None)
-        if value is None and isinstance(info, dict):
-            value = info.get(key)
-        return value
-
-    size = _parse_context_length(_field("model_info"), _field("parameters"))
-
-    if size <= 0 and own_client:
-        # An injected client is a test double or a shared listing client;
-        # only fall back to raw REST when we are talking to a real server.
-        try:
-            raw = _show_via_rest(name, host)
-            size = _parse_context_length(
-                raw.get("model_info"), raw.get("parameters")
-            )
-        except Exception:
-            size = 0
-
-    if size <= 0:
-        return None
-    _CONTEXT_CACHE[name] = size
-    return size
+    size = _parse_context_length(payload.get("model_info"), payload.get("parameters"))
+    return size if size > 0 else None
 
 
-def model_has_vision(name: str, host: str = DEFAULT_HOST, client=None) -> bool:
+def model_has_vision(name: str, host: Optional[str] = None, client=None) -> bool:
     """True when Ollama reports `vision` among the model's capabilities.
 
     Fails OPEN: if the capability query itself errors we return True and keep the
     model. Only a *successful* query that omits `vision` excludes it — a transient
     API problem must never silently hide a working model from the picker.
     """
-    if name in _VISION_CACHE:
-        return _VISION_CACHE[name]
-
-    try:
-        if client is None:
-            import ollama
-            client = ollama.Client(host=host.rstrip("/"))
-        info = client.show(name)
-        caps = getattr(info, "capabilities", None)
-        if caps is None and isinstance(info, dict):
-            caps = info.get("capabilities")
-        if caps is None:
-            return True                      # nothing reported — do not exclude
-        result = "vision" in [str(c).lower() for c in caps]
-    except Exception:
-        return True                          # unreachable — do not exclude
-
-    _VISION_CACHE[name] = result
-    return result
+    caps = model_capabilities(name, host=host, client=client)
+    if caps is None:
+        return True                          # unreachable/silent — do not exclude
+    return "vision" in caps
 
 
 class OllamaProvider(BaseProvider):
-    def __init__(self, model: str = DEFAULT_MODEL, host: str = DEFAULT_HOST):
+    def __init__(self, model: str = DEFAULT_MODEL, host: Optional[str] = None):
         try:
             import ollama  # noqa: F401
         except ImportError:
@@ -193,7 +223,10 @@ class OllamaProvider(BaseProvider):
                 "ollama package is required: pip install ollama"
             )
         self._model = model
-        self._host = host.rstrip("/")
+        # None means "let the SDK decide", which is how OLLAMA_HOST reaches us.
+        # Hardcoding localhost here sent every capability/context probe to the
+        # local daemon while the chat turns themselves went to the real server.
+        self._host = host.rstrip("/") if host else None
 
     @property
     def provider_name(self) -> str:

--- a/imagedescriber/configure_dialog.py
+++ b/imagedescriber/configure_dialog.py
@@ -71,7 +71,7 @@ class ApiKeyEditDialog(wx.Dialog):
         # Provider selection
         form_sizer.Add(wx.StaticText(panel, label="Provider:"), 0, wx.ALIGN_CENTER_VERTICAL)
         labels = [label for label, _canonical in self.PROVIDER_CHOICES]
-        self.provider_choice = wx.Choice(panel, choices=labels)
+        self.provider_choice = wx.Choice(panel, choices=labels, name="Provider")
         if self.provider:
             for i, (label, canonical) in enumerate(self.PROVIDER_CHOICES):
                 if canonical == self.provider.lower() or label.lower() == self.provider.lower():
@@ -1410,11 +1410,15 @@ class ConfigureDialog(wx.Dialog):
         plaintext copy behind would defeat the point of the store, and the
         store already outranks the config in resolution order.
         """
-        config = self.configs.get("image_describer", {})
+        config = self.configs.setdefault("image_describer", {})
         api_keys = config.get("api_keys")
         if not isinstance(api_keys, dict):
             return False
-        spellings = self._CONFIG_SPELLINGS.get(canonical, {canonical})
+        # The fallback is lowercased because the comparison below is: an
+        # unrecognised provider row (e.g. "Gemini") would otherwise never
+        # match its own config entry and could not be deleted.
+        spellings = self._CONFIG_SPELLINGS.get(
+            canonical, {str(canonical).strip().lower()})
         doomed = [k for k in api_keys
                   if str(k).strip().lower() in spellings]
         for key in doomed:
@@ -1431,6 +1435,7 @@ class ConfigureDialog(wx.Dialog):
         from idt_core.keys import key_source
 
         self.api_keys_list.Clear()
+        known = set()
         for label, canonical in ApiKeyEditDialog.PROVIDER_CHOICES:
             source = key_source(canonical)
             status = {
@@ -1442,6 +1447,24 @@ class ConfigureDialog(wx.Dialog):
             }.get(source, source)
             index = self.api_keys_list.Append(f"{label}: {status}")
             self.api_keys_list.SetClientData(index, canonical)
+            known.update(self._CONFIG_SPELLINGS.get(canonical, {canonical}))
+
+        # Any other key sitting in the config file gets a row of its own.
+        # Listing only the three canonical providers made a key written by an
+        # older build (or by hand) invisible AND undeletable — it stayed in
+        # plaintext in image_describer_config.json with no way to remove it
+        # from this screen.
+        config = self.configs.get("image_describer", {})
+        api_keys = config.get("api_keys")
+        if isinstance(api_keys, dict):
+            for name, value in api_keys.items():
+                if str(name).strip().lower() in known or name == "description":
+                    continue
+                if not (isinstance(value, str) and value.strip()):
+                    continue
+                index = self.api_keys_list.Append(
+                    f"{name}: stored in the config file (unrecognised provider)")
+                self.api_keys_list.SetClientData(index, name)
     
     def on_api_key_selected(self, event):
         """Handle API key selection"""
@@ -1468,7 +1491,11 @@ class ConfigureDialog(wx.Dialog):
             return True
 
         # No usable store on this platform: keep the config-file behaviour.
-        config = self.configs.get("image_describer", {})
+        # setdefault, not get: .get("image_describer", {}) hands back a fresh
+        # throwaway dict when the section is absent, so the key was written
+        # into a temporary that died at return - saved, reported as success,
+        # and gone.
+        config = self.configs.setdefault("image_describer", {})
         config.setdefault("api_keys", {})[canonical] = api_key
         self._save_image_describer_config()
         return True

--- a/imagedescriber/imagedescriber_wx.py
+++ b/imagedescriber/imagedescriber_wx.py
@@ -863,7 +863,23 @@ class ImageDescriberFrame(wx.Frame, ModifiedStateMixin):
             self.config['copy_originals'] = options['copy_originals']
 
     def get_api_key_for_provider(self, provider: str) -> str:
-        """Get API key for a specific provider from config"""
+        """Get API key for a specific provider.
+
+        The shared resolver comes first (env -> OS credential store -> config
+        -> legacy files). Reading only ``self.config`` used to be enough, but
+        Configure Settings now writes keys to the credential store and deletes
+        the plaintext copy from the config file — so a user who had just saved
+        a key was told by Generate Video Description that no key was set, and
+        pointed back at the very screen where they set it.
+        """
+        try:
+            from idt_core.keys import resolve_api_key
+            shared = resolve_api_key(provider)
+            if shared:
+                return shared
+        except Exception:
+            pass    # fall through to the config-file lookups below
+
         api_keys = self.config.get('api_keys', {})
         # Try case-insensitive lookup
         for key in [provider, provider.capitalize(), provider.upper(), provider.lower()]:

--- a/pytest_tests/unit/test_ollama_context_length.py
+++ b/pytest_tests/unit/test_ollama_context_length.py
@@ -43,9 +43,11 @@ class _FakeClient:
 
 @pytest.fixture(autouse=True)
 def _clear_cache():
-    ollama_mod._CONTEXT_CACHE.clear()
+    ollama_mod._SHOW_CACHE.clear()
+    ollama_mod._NEGATIVE_AT.clear()
     yield
-    ollama_mod._CONTEXT_CACHE.clear()
+    ollama_mod._SHOW_CACHE.clear()
+    ollama_mod._NEGATIVE_AT.clear()
 
 
 class TestModelContextLength:
@@ -95,12 +97,46 @@ class TestModelContextLength:
         assert model_context_length("m", client=c) == 8192
         assert c.calls == ["m"], "should query /api/show once per model"
 
-    def test_failure_is_not_cached(self):
-        """Ollama may simply not be running yet; retry next call."""
+    def test_failure_is_cached_only_briefly(self, monkeypatch):
+        """A failed probe must not be repeated on every turn — an unreachable
+        daemon would then cost a full timeout per message — but it must not be
+        remembered forever either, because Ollama may simply not be running
+        yet. So: cached for _NEGATIVE_TTL_SECONDS, retried after that.
+        """
+        clock = {"now": 1000.0}
+        monkeypatch.setattr(ollama_mod.time, "monotonic", lambda: clock["now"])
+
         c = _FakeClient(_FakeInfo(), raise_on={"m"})
-        model_context_length("m", client=c)
-        model_context_length("m", client=c)
-        assert c.calls == ["m", "m"]
+        assert model_context_length("m", client=c) is None
+        assert model_context_length("m", client=c) is None
+        assert c.calls == ["m"], "a second probe inside the TTL is wasted work"
+
+        clock["now"] += ollama_mod._NEGATIVE_TTL_SECONDS + 1
+        assert model_context_length("m", client=c) is None
+        assert c.calls == ["m", "m"], "after the TTL the daemon is tried again"
+
+    def test_a_recovered_daemon_is_picked_up_after_the_ttl(self, monkeypatch):
+        """The whole point of expiring the negative entry."""
+        clock = {"now": 500.0}
+        monkeypatch.setattr(ollama_mod.time, "monotonic", lambda: clock["now"])
+
+        c = _FakeClient(_FakeInfo(), raise_on={"m"})
+        assert model_context_length("m", client=c) is None
+
+        c._raise_on = set()
+        c._info = _FakeInfo(model_info={"llama.context_length": 8192})
+        clock["now"] += ollama_mod._NEGATIVE_TTL_SECONDS + 1
+        assert model_context_length("m", client=c) == 8192
+
+    def test_the_same_model_on_two_hosts_is_not_confused(self):
+        """A cached answer from one server must never be served for another."""
+        local = _FakeClient(_FakeInfo(model_info={"llama.context_length": 4096}))
+        remote = _FakeClient(_FakeInfo(model_info={"llama.context_length": 262144}))
+
+        assert model_context_length("m", host="http://localhost:11434",
+                                    client=local) == 4096
+        assert model_context_length("m", host="http://box:11434",
+                                    client=remote) == 262144
 
 
 class TestBudgeterIntegration:

--- a/pytest_tests/unit/test_ollama_vision_filter.py
+++ b/pytest_tests/unit/test_ollama_vision_filter.py
@@ -44,11 +44,11 @@ class _FakeClient:
 @pytest.fixture(autouse=True)
 def _clear_cache():
     from idt_core.providers import ollama as mod
-    mod._VISION_CACHE.clear()
-    mod._CAPS_CACHE.clear()
+    mod._SHOW_CACHE.clear()
+    mod._NEGATIVE_AT.clear()
     yield
-    mod._VISION_CACHE.clear()
-    mod._CAPS_CACHE.clear()
+    mod._SHOW_CACHE.clear()
+    mod._NEGATIVE_AT.clear()
 
 
 class TestIdtCoreVisionCheck:

--- a/pytest_tests/unit/test_post_266_review_fixes.py
+++ b/pytest_tests/unit/test_post_266_review_fixes.py
@@ -1,0 +1,264 @@
+"""Regressions for the findings raised after PR #266 merged.
+
+Each test here pins one defect that shipped in #266 and was fixed on top of it.
+Grouped by the thing that was wrong rather than by module, because several of
+the fixes span files (the Ollama probe rework touches the provider, the
+budgeter and the chat provider at once).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+for _p in (_ROOT, _ROOT / "shared"):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from idt_core.providers import ollama as ollama_mod  # noqa: E402
+from shared import speech_engine  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Speech: markdown cleanup must not eat code identifiers
+# ---------------------------------------------------------------------------
+
+
+class TestSpeechIdentifiers:
+    """`_EMPHASIS` treated every underscore as markdown emphasis, so a chat
+    client whose answers are full of snake_case spoke names that do not exist.
+    """
+
+    @pytest.mark.parametrize("text", [
+        "use MAX_TOOL_ROUNDS and _CAPS_CACHE now",
+        "call some_var_name first",
+        "set num_ctx via _num_ctx()",
+        "the field is max_output_tokens",
+    ])
+    def test_snake_case_survives(self, text):
+        assert speech_engine.strip_for_speech(text) == text
+
+    def test_real_emphasis_is_still_stripped(self):
+        spoken = speech_engine.strip_for_speech(
+            "This is **important** and _subtle_.")
+        assert spoken == "This is important and subtle."
+        assert "*" not in spoken and "_" not in spoken
+
+    def test_underscore_emphasis_at_word_boundaries_still_works(self):
+        assert speech_engine.strip_for_speech("a __bold__ start") == "a bold start"
+
+
+class TestScriptDirFallback:
+    """`Path(x) or fallback` never reached the fallback: Path("") is Path("."),
+    which is truthy, so a frozen build without _MEIPASS looked for the speech
+    scripts relative to the working directory."""
+
+    def test_missing_meipass_resolves_next_to_the_executable(self, monkeypatch, tmp_path):
+        exe_dir = tmp_path / "install"
+        exe_dir.mkdir()
+        monkeypatch.setattr(speech_engine.sys, "frozen", True, raising=False)
+        monkeypatch.delattr(speech_engine.sys, "_MEIPASS", raising=False)
+        monkeypatch.setattr(speech_engine.sys, "executable",
+                            str(exe_dir / "idt.exe"), raising=False)
+
+        resolved = speech_engine._script_dir()
+
+        assert resolved == exe_dir / "shared" / "speech"
+        assert resolved != Path("shared") / "speech", "must not be cwd-relative"
+
+    def test_meipass_is_used_when_present(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(speech_engine.sys, "frozen", True, raising=False)
+        monkeypatch.setattr(speech_engine.sys, "_MEIPASS", str(tmp_path), raising=False)
+
+        assert speech_engine._script_dir() == tmp_path / "shared" / "speech"
+
+
+# ---------------------------------------------------------------------------
+# Ollama probes: one cached, host-keyed /api/show
+# ---------------------------------------------------------------------------
+
+
+class _FakeInfo:
+    def __init__(self, model_info=None, parameters=None, capabilities=None):
+        self.model_info = model_info
+        self.parameters = parameters
+        self.capabilities = capabilities
+
+
+class _CountingClient:
+    def __init__(self, info):
+        self._info = info
+        self.calls = []
+
+    def show(self, name):
+        self.calls.append(name)
+        return self._info
+
+
+@pytest.fixture(autouse=True)
+def _clear_show_cache():
+    ollama_mod._SHOW_CACHE.clear()
+    ollama_mod._NEGATIVE_AT.clear()
+    yield
+    ollama_mod._SHOW_CACHE.clear()
+    ollama_mod._NEGATIVE_AT.clear()
+
+
+class TestOneProbePerModel:
+    def test_capabilities_and_context_share_one_show_call(self):
+        """Both were probed independently, so every chat turn issued two
+        round trips to the same endpoint before the first token."""
+        client = _CountingClient(_FakeInfo(
+            model_info={"qwen3.context_length": 40960},
+            capabilities=["completion", "thinking"],
+        ))
+
+        caps = ollama_mod.model_capabilities("qwen3", client=client)
+        size = ollama_mod.model_context_length("qwen3", client=client)
+        vision = ollama_mod.model_has_vision("qwen3", client=client)
+
+        assert caps == ["completion", "thinking"]
+        assert size == 40960
+        assert vision is False
+        assert client.calls == ["qwen3"], "one /api/show serves all three"
+
+
+class TestRestFallbackTrigger:
+    """The SDK drops `model_info` in some releases while still returning
+    `capabilities`. The fallback must key off that field specifically — a
+    check for "the whole response was empty" never fires on a real server,
+    which is precisely where the fallback is needed. Caught live: context
+    discovery returned None for gemma4, which reports 262,144 over REST.
+    """
+
+    def test_rest_fallback_fires_when_only_model_info_is_missing(self, monkeypatch):
+        monkeypatch.setattr(
+            ollama_mod, "_show_via_rest",
+            lambda name, host: {"model_info": {"gemma4.context_length": 262144}},
+        )
+
+        class _SdkDropsModelInfo:
+            def show(self, name):
+                return _FakeInfo(model_info=None, capabilities=["completion"])
+
+        import types
+        monkeypatch.setitem(
+            sys.modules, "ollama",
+            types.SimpleNamespace(Client=lambda host=None: _SdkDropsModelInfo()),
+        )
+
+        assert ollama_mod.model_context_length("gemma4") == 262144
+        # and the capabilities the SDK *did* return are preserved
+        assert ollama_mod.model_capabilities("gemma4") == ["completion"]
+
+
+class TestHostIsolation:
+    def test_probes_honour_ollama_host_when_none_is_given(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "box:11434")
+        assert ollama_mod._resolve_host(None) == "http://box:11434"
+
+    def test_explicit_host_wins_over_the_environment(self, monkeypatch):
+        monkeypatch.setenv("OLLAMA_HOST", "box:11434")
+        assert ollama_mod._resolve_host("http://other:1") == "http://other:1"
+
+    def test_default_is_localhost_without_the_variable(self, monkeypatch):
+        monkeypatch.delenv("OLLAMA_HOST", raising=False)
+        assert ollama_mod._resolve_host(None) == ollama_mod.DEFAULT_HOST
+
+    def test_one_hosts_answer_is_never_served_for_another(self):
+        local = _CountingClient(_FakeInfo(model_info={"llama.context_length": 4096}))
+        remote = _CountingClient(_FakeInfo(model_info={"llama.context_length": 262144}))
+
+        assert ollama_mod.model_context_length(
+            "same-name", host="http://localhost:11434", client=local) == 4096
+        assert ollama_mod.model_context_length(
+            "same-name", host="http://box:11434", client=remote) == 262144
+
+
+# ---------------------------------------------------------------------------
+# num_ctx must not ask for a KV cache the machine cannot hold
+# ---------------------------------------------------------------------------
+
+
+class TestNumCtxCeiling:
+    def _request(self, messages):
+        from idt_core.chat.messages import ChatMessage
+        from idt_core.providers.base import ChatRequest
+
+        return ChatRequest(messages=messages, model="nemotron")
+
+    def test_a_million_token_window_is_capped(self, monkeypatch):
+        """Discovery reports 1,048,576 for nemotron. The budgeter will fill a
+        window that size and num_ctx then asks Ollama to allocate it."""
+        from idt_core.chat.messages import ChatMessage
+        from idt_core.chat.providers import OllamaChatProvider
+
+        monkeypatch.setattr(ollama_mod, "model_context_length",
+                            lambda *a, **k: 1_048_576)
+        provider = OllamaChatProvider("nemotron")
+        request = self._request([ChatMessage(role="user", content="x" * 4_000_000)])
+
+        num_ctx = provider._request_options(request)["num_ctx"]
+
+        assert num_ctx == OllamaChatProvider.DEFAULT_NUM_CTX_CEILING
+        assert num_ctx < 1_048_576
+
+    def test_the_ceiling_is_overridable(self, monkeypatch):
+        from idt_core.chat.messages import ChatMessage
+        from idt_core.chat.providers import OllamaChatProvider
+
+        monkeypatch.setattr(ollama_mod, "model_context_length",
+                            lambda *a, **k: 1_048_576)
+        monkeypatch.setenv("IDT_MAX_NUM_CTX", "262144")
+        provider = OllamaChatProvider("nemotron")
+        request = self._request([ChatMessage(role="user", content="x" * 4_000_000)])
+
+        assert provider._request_options(request)["num_ctx"] == 262_144
+
+    def test_a_small_trained_window_still_wins(self, monkeypatch):
+        """The ceiling is a cap, never a licence to exceed the model."""
+        from idt_core.chat.messages import ChatMessage
+        from idt_core.chat.providers import OllamaChatProvider
+
+        monkeypatch.setattr(ollama_mod, "model_context_length", lambda *a, **k: 8192)
+        provider = OllamaChatProvider("small")
+        request = self._request([ChatMessage(role="user", content="x" * 400_000)])
+
+        assert provider._request_options(request)["num_ctx"] == 8192
+
+
+# ---------------------------------------------------------------------------
+# MLX must inline text attachments like every other formatter
+# ---------------------------------------------------------------------------
+
+
+def test_mlx_formatter_inlines_text_attachments(tmp_path):
+    """MLX accepts images only, so nothing text-shaped can be attached while
+    on MLX — but history is provider-agnostic, and a .txt attached under
+    Ollama replays through the MLX formatter. It used to vanish silently."""
+    import inspect
+
+    from idt_core.chat import mlx as mlx_mod
+
+    source = inspect.getsource(mlx_mod)
+    assert "merge_text_attachments" in source, (
+        "the MLX formatter must inline text attachments, not read msg.content"
+    )
+    assert source.count("merge_text_attachments(msg)") >= 1
+
+
+def test_text_attachment_reaches_the_mlx_prompt(tmp_path):
+    from idt_core.chat.messages import Attachment, ChatMessage
+    from idt_core.chat.providers import merge_text_attachments
+
+    path = tmp_path / "notes.txt"
+    path.write_text("PELICAN", encoding="utf-8")
+    msg = ChatMessage(role="user", content="what is in the file?",
+                      attachments=[Attachment("text/plain", path=str(path))])
+
+    merged = merge_text_attachments(msg)
+
+    assert "PELICAN" in merged
+    assert "what is in the file?" in merged

--- a/shared/speech/speak-engine.ps1
+++ b/shared/speech/speak-engine.ps1
@@ -208,8 +208,14 @@ $order = switch ($engine) {
 
 # Rates are per-engine scales, so resolve defaults separately rather than inline (PowerShell
 # 5.1 has no `if` expression).
-$oneCoreRate = 6.0
-$sapiRate    = 5
+#
+# IDT adaptation: these defaults apply whenever the config carries no rate, which for IDT is
+# the common case - the "Automatic" engine deliberately resolves no rate, so that a screen
+# reader's own rate is never overridden. Upstream defaulted to 6.0, the TOP of the OneCore
+# scale, so every IDT user with stock settings was read to at maximum speed. Default to the
+# middle of each scale instead: an unset rate should mean "normal", not "fastest".
+$oneCoreRate = 3.0
+$sapiRate    = 0
 if ($null -ne $rate) {
     $oneCoreRate = [double]$rate
     $sapiRate    = [int]$rate

--- a/shared/speech_engine.py
+++ b/shared/speech_engine.py
@@ -121,7 +121,11 @@ class SpeechSettings:
 
 def _script_dir() -> Path:
     if getattr(sys, "frozen", False):
-        base = Path(getattr(sys, "_MEIPASS", "")) or Path(sys.executable).parent
+        # `Path(x) or fallback` never reaches the fallback: Path("") is
+        # Path("."), which is truthy, so a missing _MEIPASS resolved the
+        # scripts against the current working directory. Test the string.
+        meipass = getattr(sys, "_MEIPASS", "")
+        base = Path(meipass) if meipass else Path(sys.executable).parent
         return base / "shared" / "speech"
     return Path(__file__).resolve().parent / "speech"
 
@@ -249,7 +253,12 @@ _FENCED_CODE = re.compile(r"```.*?```", re.DOTALL)
 _INLINE_CODE = re.compile(r"`([^`\n]+)`")
 _LINK = re.compile(r"\[([^\]]+)\]\([^)]+\)")
 _HEADING = re.compile(r"^#{1,6}\s*", re.MULTILINE)
-_EMPHASIS = re.compile(r"(\*{1,3}|_{1,3})(\S(?:.*?\S)?)\1")
+_EMPHASIS = re.compile(r"(\*{1,3})(\S(?:.*?\S)?)\1")
+# Underscores only count as emphasis at a word boundary. Without the
+# lookarounds this ate the internal underscores of snake_case identifiers:
+# "MAX_TOOL_ROUNDS" was spoken as "MAXTOOLROUNDS" and "some_var_name" as
+# "somevarname" — names that do not exist in the code being discussed.
+_EMPHASIS_UNDERSCORE = re.compile(r"(?<!\w)(_{1,3})(\S(?:.*?\S)?)\1(?!\w)")
 
 
 def strip_for_speech(text: str) -> str:
@@ -265,6 +274,7 @@ def strip_for_speech(text: str) -> str:
     text = _LINK.sub(r"\1", text)
     text = _HEADING.sub("", text)
     text = _EMPHASIS.sub(r"\2", text)
+    text = _EMPHASIS_UNDERSCORE.sub(r"\2", text)
     text = text.replace("|", " ")
     return text.strip()
 


### PR DESCRIPTION
A second review pass over #266 after it merged found ten issues the first pass missed. Each was verified against `main` before being fixed, and each is pinned by a test.

Related: the first pass's eight findings were fixed in 55cb3de and merged; this is the follow-up.

## Accessibility — the two that matter most

**Read-aloud spoke at maximum rate by default.** `RATE_PRESETS` has no `"auto"` key and `"auto"` is the default engine, so `resolved_rate()` returned `None` for *every* preset, including "slow". `speak-engine.ps1` then fell through to `$oneCoreRate = 6.0` — the top of the OneCore scale, as `speak-voices.ps1` itself documents. The Settings dialog compounded it: `has_rate` is False for `auto`, so the rate control is *disabled* on exactly the configuration that needed it. A user enabling read-aloud with stock settings got maximum-rate speech with no in-app remedy.

Fixed in the router rather than in Python: an unset rate now means the middle of each scale. The principle that screen-reader routes never receive a rate is deliberately preserved — that is *why* `auto` resolves to `None`, and it is correct.

**`strip_for_speech` mangled snake_case.** The emphasis regex treated every underscore as markdown: `MAX_TOOL_ROUNDS` → "MAXTOOLROUNDS", `some_var_name` → "somevarname". For a developer's chat client the listener heard identifiers that do not exist in the code being discussed. Underscore emphasis now requires word boundaries.

## Correctness

- **Saving a key broke Generate Video Description.** Configure Settings writes to the credential store and purges the plaintext config copy, but `get_api_key_for_provider` still read only `self.config` — so the guard aborted and pointed the user back at the screen where they had just set the key.
- **Context probes ignored `OLLAMA_HOST`.** `model_context_length` hardcoded localhost and built an explicit `Client`, defeating the SDK's env fallback; two of three callers passed no host at all. Remote users chatted fine while every probe hit localhost, failed, and budgeted a 262k model as 32k. Host now defaults to `None` and is part of the cache key.
- **`num_ctx` could request an unallocatable KV cache.** Discovery reports 1,048,576 for nemotron; the budgeter fills that window and the figure went straight to the server. Added a 131,072 ceiling, overridable via `IDT_MAX_NUM_CTX`. A smaller trained window still wins.
- **The MLX formatter silently dropped text attachments.** Every other formatter moved to `merge_text_attachments`; MLX still read `msg.content`. A `.txt` attached under Ollama vanished when history replayed through MLX — no error, and the model answered about a file it was never shown.
- **`_store_key` wrote into a throwaway dict.** `configs.get("image_describer", {})` returns a fresh dict when the section is absent, so on a platform with no credential store the key was saved into a temporary, reported as success, and lost.
- **`load_api_keys` hid non-canonical keys**, leaving a key from an older build invisible *and* undeletable while it sat in plaintext.

## Performance

- **Two or three blocking `/api/show` round trips per turn.** Capabilities and context length were probed separately from the same endpoint, and neither cache stored failures — so an unreachable daemon was re-probed every turn at a full timeout each. Collapsed into one cached, host-keyed `_show()`. Failures cache for 30s: long enough that a turn costs one attempt, short enough that a daemon started later is still picked up.
- **The model picker blocked the UI thread** on one `/api/show` per installed model. Moved to a worker thread with a generation token so a late result cannot repopulate the picker after a provider switch.

Also: `_script_dir()`'s frozen fallback was dead code (`Path("")` is `Path(".")`, which is truthy), and `_win_credential` took a `target` it never read.

## Rejected during verification

Recorded because they were confidently reported and are wrong:

- **`_CONFIG_SPELLINGS` vs `_CONFIG_ALIASES` divergence strands plaintext keys** — raised by two independent angles. It does not: `_purge_config_key` lowercases before matching, and the dialog's set is a superset.
- **`--no-think` can fail a turn on non-thinking models** — from the first pass. Tested live with `moondream:latest` (capabilities `completion, vision`): `think: false` returns no error. That PR comment was deleted.
- **`ai_providers.py`'s private lookups let a deleted key keep working** — `resolve_api_key` already covers a superset, so those fallbacks are unreachable dead code, not a leak.
- **Full text in `wx.ListBox` renders newlines as glyphs** — `_line_for` already collapses whitespace.

## A regression only live testing caught

The first cut of the unified `_show()` triggered the raw-REST fallback only when the *entire* SDK response was empty. Real servers return `capabilities` while dropping `model_info`, so it never fired and context discovery silently returned `None` for gemma4 — a model that reports 262,144 over REST. Unit tests passed either way.

## Testing

- Unit suite: **1401 passed, 16 skipped** (19 new tests).
- **Frozen build**: `idt.spec` rebuilt and smoke-tested — `idt 4.5.0`, and a live chat turn returns a clean answer on stdout with `[thinking…]` on stderr, exit 0. (#266 listed frozen builds as untested; this closes that for the CLI.)
- Live against local Ollama: context discovery matches the figures recorded in #266 (gemma4 262,144; nemotron 1,048,576; moondream 2,048) with **one** round trip per model instead of three.
- `num_ctx`: 4,096 for a short chat, capped at 131,072 for a 4 MB prompt against the 1M-context model.

`test_failure_is_not_cached` became `test_failure_is_cached_only_briefly`. Its original intent ("Ollama may simply not be running yet; retry next call") is preserved by the TTL; the change is that a single turn no longer pays repeated timeouts.

## Not tested

The wx dialogs interactively, including with a screen reader — the rate fix was verified by reading the router's dispatch, not by listening. Also: macOS speech routes and the Keychain path, MLX (Windows machine), and the threaded picker under a provider switch mid-listing. `tools/check_api_usage.py` shares the config-only key-reading pattern fixed in `imagedescriber_wx.py` and is left alone.

Full detail: `docs/WorkTracking/2026-08-15-session-summary.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
