### PR TITLE
Document how to read embedded descriptions, and fix TIFF embedding

### DIFF
--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -87,9 +87,11 @@ jobs:
           python -m pytest pytest_tests/unit/test_embedded_metadata_visibility.py \
             --no-cov -q -k "TestMacosFinderCommentCaveat or TestMacosImageIoMetadata" \
             | tee macos-cases.txt
-          grep -qE '^[0-9]+ passed' macos-cases.txt \
-            || { echo "::error::The macOS ImageIO/xattr cases did not run."; exit 1; }
-          if grep -qE 'skipped' macos-cases.txt; then
+          # pytest's summary is "===== 7 passed, 41 deselected in 0.2s =====",
+          # so the count is mid-line -- do not anchor with ^.
+          grep -qE '[1-9][0-9]* passed' macos-cases.txt \
+            || { echo "::error::The macOS ImageIO/xattr cases did not run."; cat macos-cases.txt; exit 1; }
+          if grep -qE '[1-9][0-9]* skipped' macos-cases.txt; then
             echo "::error::A macOS case that must run was skipped:"; cat macos-cases.txt; exit 1
           fi
         env:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -1,0 +1,81 @@
+name: "Tests (macOS)"
+
+# The suite ran on windows-latest only. macOS had a *build* job and no test job,
+# so anything platform-specific to macOS was unverified by CI -- including the
+# thing that prompted this workflow: the user guide tells macOS readers to find
+# embedded descriptions with Get Info, Spotlight and `mdls`, and nothing checked
+# that those actually return the description.
+#
+# Get Info, Spotlight search and mdls all read kMDItemDescription, which macOS
+# populates from the XMP packet the embedder writes. Asserting on that key on
+# real Apple hardware is asserting on what a reader following the guide sees.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  test-macos:
+    name: "Suite on macOS"
+    runs-on: macos-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v7
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Report the Spotlight tools available
+        # Diagnostic, not a gate. If the embedded-metadata job below fails on a
+        # runner, the first question is whether mdls/mdimport are present and
+        # whether indexing is on -- answer it here rather than by guessing.
+        run: |
+          echo "mdls:     $(command -v mdls || echo MISSING)"
+          echo "mdimport: $(command -v mdimport || echo MISSING)"
+          mdutil -s / || true
+
+      - name: Embedded-metadata visibility on macOS
+        # Run this before the full suite so a failure here is unmissable rather
+        # than buried in 1700 dots. IDT_REQUIRE_SPOTLIGHT turns "Spotlight had
+        # nothing to say" from a skip into a failure: a macOS check that always
+        # skips is indistinguishable from a pass, which is the trap the coverage
+        # job documents.
+        run: |
+          python -m pytest pytest_tests/unit/test_embedded_metadata_visibility.py \
+            -v --no-cov -p no:randomly
+        env:
+          IDT_QUIET_CONFIG_LOG: "1"
+          IDT_REQUIRE_SPOTLIGHT: "1"
+
+      - name: Prove the macOS cases actually ran
+        # A green run above means nothing if every darwin-only test was skipped
+        # because sys.platform was misread or the class was renamed.
+        run: |
+          python -m pytest pytest_tests/unit/test_embedded_metadata_visibility.py \
+            -q --no-cov -p no:randomly -k TestMacosSpotlightMetadata \
+            | tee macos-cases.txt
+          grep -qE '[1-9][0-9]* passed' macos-cases.txt \
+            || { echo "No macOS Spotlight test passed -- they all skipped."; exit 1; }
+        env:
+          IDT_QUIET_CONFIG_LOG: "1"
+          IDT_REQUIRE_SPOTLIGHT: "1"
+
+      - name: Run the full suite
+        run: python -m pytest pytest_tests/ -q --no-cov
+        env:
+          IDT_QUIET_CONFIG_LOG: "1"

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -4,11 +4,21 @@ name: "Tests (macOS)"
 # so anything platform-specific to macOS was unverified by CI -- including the
 # thing that prompted this workflow: the user guide tells macOS readers to find
 # embedded descriptions with Get Info, Spotlight and `mdls`, and nothing checked
-# that those actually return the description.
+# that those return anything.
 #
-# Get Info, Spotlight search and mdls all read kMDItemDescription, which macOS
-# populates from the XMP packet the embedder writes. Asserting on that key on
-# real Apple hardware is asserting on what a reader following the guide sees.
+# What a GitHub runner can and cannot verify, established by running it:
+#
+#   xattr     ✓ Finder comments are an extended attribute. No daemon involved.
+#   ImageIO   ✓ The framework Get Info, Preview and the Spotlight importer all
+#               sit on. Needs pyobjc, no daemon.
+#   mdls      ✗ Reads the Spotlight index. Runners index nothing, so mdls exits
+#               0 and reports (null) for every file.
+#   mdimport  ✗ Crashes on the runner: 'NSInvalidArgumentException ... -[NSNull
+#               length]' before printing anything.
+#
+# So the Spotlight cases skip here by design and the ImageIO cases carry the
+# load, being one framework layer below the same answer. Run the suite on a real
+# Mac with IDT_REQUIRE_SPOTLIGHT=1 to exercise `mdls` itself.
 
 on:
   push:
@@ -40,10 +50,19 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Report the Spotlight tools available
-        # Diagnostic, not a gate. If the embedded-metadata job below fails on a
-        # runner, the first question is whether mdls/mdimport are present and
-        # whether indexing is on -- answer it here rather than by guessing.
+      - name: Install pyobjc for the ImageIO checks
+        # ImageIO is how Get Info and Preview read an image's metadata. Querying
+        # it directly is the closest a headless runner gets to opening Get Info.
+        run: pip install pyobjc-framework-Quartz
+
+      - name: Verify Quartz is importable
+        # An importorskip that always skips is indistinguishable from a pass.
+        run: python -c "import Quartz; print('Quartz OK')"
+
+      - name: Report Spotlight state
+        # Diagnostic only. If the ImageIO cases ever start failing, the first
+        # question is what this runner actually has -- answer it here rather
+        # than by guessing.
         run: |
           echo "mdls:     $(command -v mdls || echo MISSING)"
           echo "mdimport: $(command -v mdimport || echo MISSING)"
@@ -51,29 +70,30 @@ jobs:
 
       - name: Embedded-metadata visibility on macOS
         # Run this before the full suite so a failure here is unmissable rather
-        # than buried in 1700 dots. IDT_REQUIRE_SPOTLIGHT turns "Spotlight had
-        # nothing to say" from a skip into a failure: a macOS check that always
-        # skips is indistinguishable from a pass, which is the trap the coverage
-        # job documents.
+        # than buried in 1700 dots.
         run: |
-          python -m pytest pytest_tests/unit/test_embedded_metadata_visibility.py \
-            -v --no-cov -p no:randomly
+          python -m pytest pytest_tests/unit/test_embedded_metadata_visibility.py -v --no-cov
         env:
           IDT_QUIET_CONFIG_LOG: "1"
-          IDT_REQUIRE_SPOTLIGHT: "1"
 
       - name: Prove the macOS cases actually ran
-        # A green run above means nothing if every darwin-only test was skipped
-        # because sys.platform was misread or the class was renamed.
+        # A green run above means nothing if every darwin-only case skipped
+        # because sys.platform was misread or a class was renamed. pytest's exit
+        # code is checked separately from the count, because piping it into a
+        # counter would otherwise swallow a failing run: this step's default
+        # shell is `bash -e`, which does not set pipefail.
         run: |
+          set -o pipefail
           python -m pytest pytest_tests/unit/test_embedded_metadata_visibility.py \
-            -q --no-cov -p no:randomly -k TestMacosSpotlightMetadata \
+            --no-cov -q -k "TestMacosFinderCommentCaveat or TestMacosImageIoMetadata" \
             | tee macos-cases.txt
-          grep -qE '[1-9][0-9]* passed' macos-cases.txt \
-            || { echo "No macOS Spotlight test passed -- they all skipped."; exit 1; }
+          grep -qE '^[0-9]+ passed' macos-cases.txt \
+            || { echo "::error::The macOS ImageIO/xattr cases did not run."; exit 1; }
+          if grep -qE 'skipped' macos-cases.txt; then
+            echo "::error::A macOS case that must run was skipped:"; cat macos-cases.txt; exit 1
+          fi
         env:
           IDT_QUIET_CONFIG_LOG: "1"
-          IDT_REQUIRE_SPOTLIGHT: "1"
 
       - name: Run the full suite
         run: python -m pytest pytest_tests/ -q --no-cov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,7 +113,21 @@
 - Removed: `idt_core/providers/florence.py`, the GUI `HuggingFaceProvider`, provider wiring in the CLI/guide/config dialogs, the Florence hidden imports from `idt.spec` / `imagedescriber_wx.spec`, the Florence-only dependencies (`transformers`, `torch`, `torchvision`, `einops`, `timm`) from the top-level `requirements.txt`, and `docs/HUGGINGFACE_PROVIDER_GUIDE.md`.
 - The macOS-only MLX provider and its `torch`/`transformers` dependencies are unaffected.
 
+### 📚 Documentation
+
+**The user guide now says how to read an embedded description back**
+- Embedding shipped without telling anyone where the description ends up. **User Guide → Embedding Descriptions into Images** now covers it for both platforms.
+- Windows: switch File Explorer to Details view, tab to the column headers, **Shift+F10**, and turn on **Comments** or **Title** — plus which column each format actually fills, since PNG has no EXIF and only appears under Title.
+- macOS: **Cmd+I** for Get Info, Preview's Inspector, Spotlight, `mdls`, and Photos captions. Also states plainly that Finder's **Comments** column is a Spotlight note stored by Finder, *not* the embedded description, so switching it on shows nothing.
+- `IMAGE_FORMAT_SUPPORT.md` corrected against measured behavior: it claimed Windows shows no PNG metadata at all (it shows it under Title), and described TIFF as lossless piexif insertion (it was the corrupting path fixed below).
+
 ### 🔧 Bug Fixes
+
+**Embedding a description into a TIFF no longer destroys the file**
+- `.tif` and `.tiff` were routed to the JPEG writer, which injected a JPEG APP1 segment over the `II*\0` byte-order magic. The result was not a TIFF missing its description — it was a file Pillow, File Explorer and Preview all refused to open. Nothing raised; the embed reported success.
+- TIFF now gets its own writer, setting `ImageDescription` (270) and `XPComment` (40092) through Pillow, so the description reaches Explorer's **Title**, **Subject** and **Comments** columns.
+- Format dispatch moved into one `_embed_by_format()` helper. An unrecognized extension is copied and left alone rather than being handed to a writer that guesses.
+- `pytest_tests/unit/test_embedded_metadata_visibility.py` reads the embedded files back the way each OS does — EXIF UserComment, XMP `dc:description`, PNG chunks, TIFF tags, and on Windows the actual Explorer column values via the shell property system. Seven of its cases fail against the old code.
 
 **`idt guideme` no longer shows MLX as a provider option on Windows (issue #111)**
 - MLX (Apple Metal) is now only listed as a provider choice on macOS.

--- a/docs/IMAGE_FORMAT_SUPPORT.md
+++ b/docs/IMAGE_FORMAT_SUPPORT.md
@@ -6,38 +6,43 @@ This document lists which image formats support embedding AI-generated descripti
 
 | Format | File Extensions | Embedding Method | Notes |
 |--------|-----------------|------------------|-------|
-| **JPEG** | .jpg, .jpeg | EXIF via piexif | Lossless insertion—no image re-encoding |
-| **TIFF** | .tif, .tiff | EXIF via piexif | Lossless insertion—no image re-encoding |
-| **PNG** | .png | tEXt metadata chunk | Preserves existing text chunks; standardized metadata structure |
+| **JPEG** | .jpg, .jpeg | EXIF via piexif + XMP packet | Lossless insertion—no image re-encoding |
+| **TIFF** | .tif, .tiff | IFD tags via Pillow | File is rewritten; pixel data is unchanged |
+| **PNG** | .png | tEXt metadata chunk + XMP iTXt chunk | Preserves existing text chunks; standardized metadata structure |
 | **WebP** | .webp | EXIF blob | Requires re-save at quality 95 or lossless setting |
 | **HEIC/HEIF** | .heic, .heif | Convert → JPEG | Original is left unmodified; conversion happens in copy workflow |
 
 ### Embedding Locations
 
-- **JPEG/TIFF**: `EXIF ImageDescription` (main metadata), `EXIF UserComment` (attribution with model + timestamp)
-- **PNG**: `tEXt` chunk key: `Description` (also includes XMP `dc:description` via Adobe XMP format)
-- **WebP**: EXIF blob (same fields as JPEG)
+- **JPEG**: `EXIF UserComment` and XMP `dc:description`
+- **TIFF**: `ImageDescription` tag (270) and `XPComment` tag (40092)
+- **PNG**: `tEXt` chunk key `Description`, plus XMP `dc:description` in an `XML:com.adobe.xmp` iTXt chunk
+- **WebP**: `EXIF UserComment`
 - **HEIC/HEIF**: Converted to JPEG, then embedded using JPEG method
 
-### Important: Windows File Explorer Display Limitation
+TIFF cannot reuse the JPEG writer: TIFF keeps its metadata in the IFD, and injecting a
+JPEG APP1 segment overwrites the byte-order magic and leaves an unopenable file. This was
+a live bug until the format dispatcher in `idt_core/embedder.py` gained a TIFF branch.
 
-**PNG metadata IS embedded correctly, but Windows doesn't show it in Properties → Details.**
+### Which Windows Explorer Column Shows the Description
 
-- **JPEG**: Windows reads EXIF metadata → displays in "Comments" field ✓
-- **PNG**: Windows does NOT read tEXt chunks or XMP → "Comments" field remains empty ✗
+Windows maps the underlying tags onto its own property names, and the mapping differs by
+format. Measured on Windows 11 via the shell property system, and pinned by
+`pytest_tests/unit/test_embedded_metadata_visibility.py`:
 
-**The metadata is still there.** To verify:
+| Format | "Comments" column | "Title" column |
+|--------|-------------------|----------------|
+| **JPEG** | ✓ (from EXIF UserComment) | ✓ (from XMP `dc:description`) |
+| **PNG** | ✗ — PNG has no EXIF | ✓ (from the XMP iTXt chunk) |
+| **WebP** | ✓ (from EXIF UserComment) | ✗ — no XMP is written |
+| **TIFF** | ✓ (from XPComment) | ✓ (from ImageDescription) |
 
-1. **Online viewer** (easiest): Upload to https://exif.tools/ → see full tEXt chunks
-2. **Command-line**: `exiftool IMG_4499.PNG`
-3. **Python**:
-   ```python
-   from PIL import Image
-   img = Image.open('IMG_4499.PNG')
-   print(img.text['Description'])  # Full description text
-   ```
+So **Comments** is the right column for JPEG and WebP, and PNG users need **Title** instead.
+The earlier claim that Windows shows nothing at all for PNG was wrong: Windows does read the
+XMP packet, it just does not surface it under "Comments".
 
-**Why the difference?** JPEG embeds metadata in EXIF IFD (a standardized binary format). PNG uses tEXt chunks (text key-value pairs). Windows only exposes EXIF data in its UI, not PNG tEXt. Most modern image viewers, online tools, and mobile apps correctly read PNG tEXt metadata.
+See [USER_GUIDE.md](USER_GUIDE.md) → *Embedding Descriptions into Images* for the keyboard
+steps to switch a column on, and for the macOS equivalents.
 
 ---
 
@@ -125,10 +130,11 @@ If you need to confirm that descriptions were successfully embedded:
 
 | Format | Method | Command |
 |--------|--------|---------|
-| **JPEG** | Windows Properties → Details → Comments | ✓ Works natively |
-| **PNG** | Online tool | `exiftool file.png` or https://exif.tools/ |
-| **TIFF** | Windows Properties → Details → Comments | ✓ Works natively |
-| **WebP** | Online tool | `exiftool file.webp` or https://exif.tools/ |
+| **JPEG** | Windows Properties → Details → Comments or Title | ✓ Works natively |
+| **PNG** | Windows Properties → Details → Title | ✓ Works natively (not under Comments) |
+| **TIFF** | Windows Properties → Details → Comments or Title | ✓ Works natively |
+| **WebP** | Windows Properties → Details → Comments | ✓ Works natively |
+| **All formats** | macOS | `mdls -name kMDItemDescription file` |
 | **All formats** | Python | `from PIL import Image; img = Image.open(path); print(img.text.get('Description'))` |
 
 ---
@@ -148,4 +154,4 @@ If you need to confirm that descriptions were successfully embedded:
 
 For now, the existing format coverage is sufficient and well-maintained.
 
-**Note on PNG verification:** PNG metadata is reliably embedded but not visible in Windows File Explorer. Use the verification methods above to confirm the data is present.
+**Note on PNG verification:** PNG descriptions do not appear under Windows' "Comments" property, only under "Title". If Comments looks empty for a PNG, that is the expected mapping, not a failed embed.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1479,8 +1479,10 @@ You can also search on the embedded text: type it into the Explorer search box a
 |----------------|---------|
 | JPEG (the usual case) | **Comments** or **Title**—both are filled |
 | PNG | **Title** (PNG has no EXIF, so **Comments** stays blank) |
-| WebP | **Comments** |
+| WebP | **Comments**—requires the Microsoft WebP Image Extension (see below) |
 | TIFF | **Comments** or **Title** |
+
+**WebP needs a codec.** Explorer reads WebP metadata through the Microsoft WebP Image Extension. Windows 11 installs normally have it, but on Windows Server or a stripped-down build it may be missing—and without it Explorer shows *no* image columns for WebP at all, not just an empty Comments. If Dimensions is blank too, install the extension from the Microsoft Store.
 
 #### Reading Embedded Descriptions on macOS
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1444,6 +1444,59 @@ Key points:
 - HEIC sources are converted to JPEG before embedding (HEIC is a read-only format for this purpose).
 - In-place mode (modify originals) requires explicit confirmation and is not recommended unless you have backups.
 
+#### Where the Description Is Stored
+
+Different image formats have different metadata containers, so IDT writes to whichever fields that format actually supports:
+
+| Format | Fields written |
+|--------|----------------|
+| JPEG | EXIF UserComment, XMP `dc:description` |
+| PNG | tEXt `Description` chunk, XMP `dc:description` |
+| WebP | EXIF UserComment |
+| TIFF | ImageDescription tag, XPComment tag |
+
+This matters for the next two sections: which field a format gets determines where the description shows up on your desktop. PNG files, for example, have no EXIF at all, so the Windows **Comments** column stays empty for them and you need the **Title** column instead.
+
+#### Reading Embedded Descriptions on Windows
+
+File Explorer can show the description as a column in Details view, which means you can read every description in a folder by arrowing down the list.
+
+1. Open the folder holding the embedded copies (`<workspace>/embedded/`).
+2. Switch to **Details** view (**Ctrl+Shift+6**, or the **View** menu).
+3. Press **Tab** until focus reaches the column headers.
+4. Press **Shift+F10** for the context menu of available columns.
+5. Turn on **Comments** (JPEG, WebP and TIFF) or **Title** (JPEG, PNG and TIFF).
+
+If the column you want is not on the short list, choose **More...** at the bottom of that menu and find it in the full list.
+
+Once the column is on, arrow through the file list and the description is announced along with the file name. To read a single file's description instead, select it and press **Alt+Enter** for **Properties**, then move to the **Details** tab—the description appears under **Description → Title** and **Comments**.
+
+You can also search on the embedded text: type it into the Explorer search box and Windows matches against these fields, so `sunset` finds every photo whose description mentions one.
+
+**Choosing a column:**
+
+| Your files are | Turn on |
+|----------------|---------|
+| JPEG (the usual case) | **Comments** or **Title**—both are filled |
+| PNG | **Title** (PNG has no EXIF, so **Comments** stays blank) |
+| WebP | **Comments** |
+| TIFF | **Comments** or **Title** |
+
+#### Reading Embedded Descriptions on macOS
+
+macOS has no Finder column for embedded descriptions—the **Comments** column in Finder's list view shows *Spotlight Comments*, which is a note stored separately by Finder, not the description inside the file. Turning it on will show nothing. Use one of these instead:
+
+- **Finder Get Info** — select the file and press **Cmd+I**. The description appears in the **More Info** section. This is the quickest way to check a single file, and VoiceOver reads the field directly.
+- **Preview** — open the image, then **Tools → Show Inspector** (**Cmd+I**). The **ⓘ** tab has **General**, **Exif** and **TIFF** panes showing the raw fields.
+- **Spotlight search** — the description is indexed, so searching for a word from it finds the photo.
+- **Terminal** — `mdls -name kMDItemDescription photo.jpg` prints the description for one file. To list a whole folder:
+
+  ```bash
+  for f in *.jpg; do echo "$f: $(mdls -raw -name kMDItemDescription "$f")"; done
+  ```
+
+- **Photos** — importing an embedded copy brings the description in as the photo's caption, where it is visible in the Info pane and searchable.
+
 ---
 
 ### Combining Multiple Workspaces

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1497,6 +1497,8 @@ macOS has no Finder column for embedded descriptions—the **Comments** column i
 
 - **Photos** — importing an embedded copy brings the description in as the photo's caption, where it is visible in the Info pane and searchable.
 
+Unlike Windows, macOS needs no per-format advice here: Get Info and Preview read through ImageIO, which reports the description for JPEG, PNG, WebP and TIFF alike.
+
 ---
 
 ### Combining Multiple Workspaces

--- a/docs/WorkTracking/2026-08-19-session-summary.md
+++ b/docs/WorkTracking/2026-08-19-session-summary.md
@@ -78,22 +78,95 @@ Result: 35 passed. Against the pre-fix embedder, 7 fail.
 
 Full suite: 1715 passed, 34 skipped.
 
+## Reviewed, then fixed
+
+An independent review pass over the first commit found three things worth having.
+
+**Multi-page TIFF was being flattened.** Pillow's `save()` writes only the frame
+currently seeked unless `save_all` is passed, so a four-page scan came back as
+one page with nothing raised. In-place mode dropped the other three off the only
+copy. TIFF is the format `IMAGE_FORMAT_SUPPORT.md` calls archival, which is
+precisely the multi-page case.
+
+Fixing that exposed a second layer underneath: `seek()` rewrites `tag_v2` in
+place rather than returning a new object, so the tags set before walking the
+frames were wiped by the walk. Pages came back and the description did not. The
+IFD is now read after iteration. Both halves have their own test, because each
+failed silently on its own.
+
+**The macOS job could not pass on GitHub hardware** — see below.
+
+**The CI guard hid failures.** `pytest | tee` returns tee's exit status, and the
+step's default shell is `bash -e`, which does not set pipefail. Fixed with an
+explicit `set -o pipefail`, and a skip in the must-run classes is now an error.
+
+## What macOS CI can and cannot verify
+
+Established by running it, not by reasoning about it:
+
+| Reader | On a GitHub runner | Why |
+|--------|--------------------|-----|
+| `xattr` | ✓ works | Finder comments are an extended attribute; no daemon |
+| ImageIO | ✓ works | Needs pyobjc, no index |
+| `mdls` | ✗ returns `(null)` | Reads the Spotlight index; runners index nothing |
+| `mdimport` | ✗ crashes | `NSInvalidArgumentException ... -[NSNull length]` |
+
+The first attempt set `IDT_REQUIRE_SPOTLIGHT=1` and got 5 failed, 30 passed. So
+the macOS cases were rebuilt on readers a runner can actually run. ImageIO is the
+framework Get Info, Preview and the Spotlight importer all sit on, so it is one
+layer below the same answer rather than a weaker substitute.
+
+**What the macOS run settled:** ImageIO reports the description for JPEG, PNG,
+WebP and TIFF alike, as IPTC `Caption/Abstract` and EXIF `UserComment`. The open
+question about whether TIFF reaches macOS is answered — it does — so the guide's
+macOS section needs no per-format carve-out, unlike the Windows column table.
+
+Seven macOS cases pass on Apple hardware. The two `mdls` cases skip on CI and run
+for real on a Mac with `IDT_REQUIRE_SPOTLIGHT=1`.
+
+## What the Windows runner settled
+
+`test_webp_appears_in_comments_column` passes on Kelly's Windows 11 desktop and
+failed on the runner. Explorer reads WebP properties through the Microsoft WebP
+Image Extension; desktop installs have it, CI images do not, and without it the
+shell has no property handler for `.webp` at all — Dimensions, Bit depth and
+Width come back empty alongside Comments.
+
+The test separates the two cases rather than being loosened: no Dimensions means
+no handler and skips with that reason; Dimensions present but Comments empty
+still fails. Readers get told too, because a missing codec looks exactly like a
+failed embed.
+
+## Test coverage
+
+Before: `TestEmbedder` and `TestXmpInjection` in `test_idt_core.py` proved copies
+land in the right place and carry XMP. Nothing asserted *which* tag any format
+got, so nothing would have caught a change that left an Explorer column blank —
+or the TIFF corruption.
+
+The new file reads the files back the way each OS does: EXIF UserComment via
+piexif, XMP `dc:description` parsed out, PNG tEXt and iTXt chunks, TIFF tags 270
+and 40092, unicode round-trip per format, every embedded file still opens,
+sources never modified, unknown formats byte-identical after copy. Then the
+platform layer — real Explorer column values on Windows, `xattr` and ImageIO on
+macOS — and assertions that the guide still contains the instructions.
+
+48 cases. On Windows: 39 passed, 9 skipped (macOS-only). Full suite 1720 passed.
+All six CI checks green, including the new macOS job.
+
 ## What was NOT tested
 
-- **macOS instructions were not verified on a Mac.** No macOS machine in this
-  session. The Get Info / Preview Inspector / Spotlight / `mdls` / Photos routes
-  rest on the XMP `dc:description` field, which *is* verified present by the new
-  tests, and on the user's own report that Get Info shows it. But nobody ran
-  `mdls` against an embedded file here, and the "More Info section" placement in
-  Get Info is from the user's description, not observation. Worth a confirming
-  pass on a Mac before anyone relies on the exact wording.
-- **HEIC** was not exercised. It converts to JPEG first, so it inherits the JPEG
-  path the tests do cover, but no HEIC file went through end to end.
-- **The published HTML** was not rendered. Pandoc is not installed locally, so the
-  new tables and the nested fenced code block in the macOS bullet list have not
-  been seen through the real publish pipeline — only checked for correct
-  indentation. The GitHub Pages workflow rebuilds on merge to `main`.
-- **Explorer's own UI** was not driven. The column values were read from the shell
-  property system rather than by tabbing to a header and pressing Shift+F10, so
-  the keystroke sequence in the guide is unverified as a sequence, even though
-  every column it names is confirmed populated.
+- **`mdls` itself has never been run against an embedded file.** It is the
+  command printed in the guide, and CI cannot exercise it. The ImageIO tests
+  cover the layer beneath it on real macOS, which is strong evidence but not the
+  same thing. Running the suite on a Mac with `IDT_REQUIRE_SPOTLIGHT=1` closes
+  this, and is worth doing once.
+- **No GUI was driven on either platform.** Explorer columns were read from the
+  shell property system rather than by tabbing to a header and pressing
+  Shift+F10, and Get Info was never opened. Every field the instructions name is
+  confirmed populated; the keystroke sequences are unverified as sequences.
+- **HEIC** was not exercised end to end. It converts to JPEG first, so it
+  inherits a covered path.
+- **The published HTML** was not rendered. Pandoc is not installed locally, so
+  the new tables and the nested code block were checked for indentation only.
+  The Pages workflow rebuilds on merge to `main`.

--- a/docs/WorkTracking/2026-08-19-session-summary.md
+++ b/docs/WorkTracking/2026-08-19-session-summary.md
@@ -14,8 +14,9 @@ have no way to confirm anything happened.
 | `docs/USER_GUIDE.md` | Expanded *Embedding Descriptions into Images* with a field-by-format table and two new subsections: Windows and macOS access steps |
 | `docs/IMAGE_FORMAT_SUPPORT.md` | Corrected three claims that measurement contradicted |
 | `idt_core/embedder.py` | New `_embed_by_format()` dispatcher; new `_embed_tiff()`; TIFF no longer routed to the JPEG writer |
-| `pytest_tests/unit/test_embedded_metadata_visibility.py` | New — 35 tests |
+| `pytest_tests/unit/test_embedded_metadata_visibility.py` | New — 48 tests |
 | `CHANGELOG.md` | Documentation and Bug Fixes entries under Unreleased |
+| `.github/workflows/test-macos.yml` | New — the suite had never run on macOS |
 
 ## What was measured, not assumed
 
@@ -52,31 +53,6 @@ is copied and left alone instead of handed to whichever writer looked closest.
 `_embed_one()` in the `Embedder` class never had the TIFF branch, so project-mode
 embeds silently skipped metadata for TIFF rather than corrupting it. It now goes
 through the same dispatcher and gets the tags.
-
-## Test coverage
-
-Before: `TestEmbedder` and `TestXmpInjection` in `test_idt_core.py` proved copies
-land in the right place and carry XMP. Nothing asserted *which* tag any format
-got, so nothing would have caught a change that left an Explorer column blank —
-or the TIFF corruption.
-
-New file reads the files back the way each OS does:
-
-- EXIF UserComment via piexif (JPEG, WebP)
-- XMP `dc:description` extracted and parsed (JPEG, PNG)
-- PNG tEXt and iTXt chunks
-- TIFF tags 270 and 40092
-- Unicode round-trip per format — UserComment is UCS-2, XMP is UTF-8
-- Every embedded file still opens
-- Sources never modified; unknown formats byte-identical after copy
-- **Windows only:** actual Explorer column values via the shell property system,
-  asserting the exact instruction the guide gives
-- The guide itself still contains the Windows steps, the macOS steps and the
-  Spotlight Comments caveat
-
-Result: 35 passed. Against the pre-fix embedder, 7 fail.
-
-Full suite: 1715 passed, 34 skipped.
 
 ## Reviewed, then fixed
 

--- a/docs/WorkTracking/2026-08-19-session-summary.md
+++ b/docs/WorkTracking/2026-08-19-session-summary.md
@@ -1,0 +1,99 @@
+# 2026-08-19 — Reading embedded descriptions back, on Windows and macOS
+
+## What prompted this
+
+The user guide explained how to embed descriptions into images and then stopped.
+It never said where the description ends up or how to look at it, which makes the
+feature hard to trust: you run `idt embed`, you get a folder of copies, and you
+have no way to confirm anything happened.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `docs/USER_GUIDE.md` | Expanded *Embedding Descriptions into Images* with a field-by-format table and two new subsections: Windows and macOS access steps |
+| `docs/IMAGE_FORMAT_SUPPORT.md` | Corrected three claims that measurement contradicted |
+| `idt_core/embedder.py` | New `_embed_by_format()` dispatcher; new `_embed_tiff()`; TIFF no longer routed to the JPEG writer |
+| `pytest_tests/unit/test_embedded_metadata_visibility.py` | New — 35 tests |
+| `CHANGELOG.md` | Documentation and Bug Fixes entries under Unreleased |
+
+## What was measured, not assumed
+
+The whole point of the new guide section is telling someone which column to switch
+on, so guessing was not an option. Every claim was checked on this Windows 11
+machine by querying the shell property system (`Shell.Application.GetDetailsOf`),
+which is the same source Explorer draws its columns from.
+
+| Format | Comments column | Title column |
+|--------|-----------------|--------------|
+| JPEG | ✓ EXIF UserComment | ✓ XMP `dc:description` |
+| PNG | ✗ (no EXIF) | ✓ XMP iTXt chunk |
+| WebP | ✓ EXIF UserComment | ✗ (no XMP written) |
+| TIFF | ✓ XPComment | ✓ ImageDescription |
+
+The user's instinct — Details view, tab to headers, Shift+F10, turn on Comments or
+Title — is correct, with the PNG exception worth calling out.
+
+## The TIFF bug this turned up
+
+Writing the format table meant embedding into one of each format and looking at
+the result. The TIFF would not open afterwards.
+
+`embed_image_file()` routed `.tif` and `.tiff` to `_embed_jpeg()`, which walks
+JPEG marker segments and injects an APP1. Run against a TIFF that overwrites the
+`II*\0` byte-order magic — the file began `II\xff\xe1` — and Pillow, Explorer and
+Preview all refused it. Nothing raised. The embed reported success and the user
+got a folder of dead files.
+
+Fixed by giving TIFF its own writer (`ImageDescription` 270 + `XPComment` 40092
+via Pillow) and putting format dispatch in one place, where an unknown extension
+is copied and left alone instead of handed to whichever writer looked closest.
+
+`_embed_one()` in the `Embedder` class never had the TIFF branch, so project-mode
+embeds silently skipped metadata for TIFF rather than corrupting it. It now goes
+through the same dispatcher and gets the tags.
+
+## Test coverage
+
+Before: `TestEmbedder` and `TestXmpInjection` in `test_idt_core.py` proved copies
+land in the right place and carry XMP. Nothing asserted *which* tag any format
+got, so nothing would have caught a change that left an Explorer column blank —
+or the TIFF corruption.
+
+New file reads the files back the way each OS does:
+
+- EXIF UserComment via piexif (JPEG, WebP)
+- XMP `dc:description` extracted and parsed (JPEG, PNG)
+- PNG tEXt and iTXt chunks
+- TIFF tags 270 and 40092
+- Unicode round-trip per format — UserComment is UCS-2, XMP is UTF-8
+- Every embedded file still opens
+- Sources never modified; unknown formats byte-identical after copy
+- **Windows only:** actual Explorer column values via the shell property system,
+  asserting the exact instruction the guide gives
+- The guide itself still contains the Windows steps, the macOS steps and the
+  Spotlight Comments caveat
+
+Result: 35 passed. Against the pre-fix embedder, 7 fail.
+
+Full suite: 1715 passed, 34 skipped.
+
+## What was NOT tested
+
+- **macOS instructions were not verified on a Mac.** No macOS machine in this
+  session. The Get Info / Preview Inspector / Spotlight / `mdls` / Photos routes
+  rest on the XMP `dc:description` field, which *is* verified present by the new
+  tests, and on the user's own report that Get Info shows it. But nobody ran
+  `mdls` against an embedded file here, and the "More Info section" placement in
+  Get Info is from the user's description, not observation. Worth a confirming
+  pass on a Mac before anyone relies on the exact wording.
+- **HEIC** was not exercised. It converts to JPEG first, so it inherits the JPEG
+  path the tests do cover, but no HEIC file went through end to end.
+- **The published HTML** was not rendered. Pandoc is not installed locally, so the
+  new tables and the nested fenced code block in the macOS bullet list have not
+  been seen through the real publish pipeline — only checked for correct
+  indentation. The GitHub Pages workflow rebuilds on merge to `main`.
+- **Explorer's own UI** was not driven. The column values were read from the shell
+  property system rather than by tabbing to a header and pressing Shift+F10, so
+  the keystroke sequence in the guide is unverified as a sequence, even though
+  every column it names is confirmed populated.

--- a/idt_core/embedder.py
+++ b/idt_core/embedder.py
@@ -14,7 +14,11 @@ For PNG:
   - iTXt chunk "XML:com.adobe.xmp" → XMP dc:description for modern apps
 
 For WebP:
-  - EXIF UserComment + XMP dc:description
+  - EXIF UserComment  → Windows "Comments" column
+
+For TIFF:
+  - ImageDescription tag (270) → Windows "Title" and "Subject" columns
+  - XPComment tag (40092)      → Windows "Comments" column
 
 HEIC originals in copy mode use the .idt/ JPEG conversion if available;
 otherwise they are converted fresh and that copy is embedded into.
@@ -45,6 +49,10 @@ _XML = "http://www.w3.org/XML/1998/namespace"
 
 _XMP_JPEG_HEADER = b"http://ns.adobe.com/xap/1.0/\x00"
 _EXIF_HEADER     = b"Exif\x00\x00"
+
+# TIFF/EXIF tag numbers used by the TIFF branch
+_TIFF_IMAGE_DESCRIPTION = 270
+_TIFF_XP_COMMENT        = 40092
 
 # ------------------------------------------------------------------ #
 # Result type                                                          #
@@ -87,13 +95,7 @@ def embed_image_file(
     """
     if dest == source:
         # In-place mode: embed directly, no copy step
-        suffix = source.suffix.lower()
-        if suffix in (".jpg", ".jpeg", ".tif", ".tiff"):
-            _embed_jpeg(source, description)
-        elif suffix == ".png":
-            _embed_png(source, description)
-        elif suffix == ".webp":
-            _embed_webp(source, description)
+        _embed_by_format(source, description)
         return
 
     if not overwrite and dest.exists():
@@ -102,13 +104,25 @@ def embed_image_file(
     dest.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(source, dest)
 
-    suffix = dest.suffix.lower()
-    if suffix in (".jpg", ".jpeg", ".tif", ".tiff"):
-        _embed_jpeg(dest, description)
+    _embed_by_format(dest, description)
+
+
+def _embed_by_format(path: Path, description: str) -> None:
+    """Dispatch to the right embedder for *path*'s extension.
+
+    Unknown formats are left alone: the copy still exists, it just carries no
+    description. Never guess a format -- running the JPEG segment writer over a
+    TIFF corrupts the file, which is exactly what this dispatcher exists to stop.
+    """
+    suffix = path.suffix.lower()
+    if suffix in (".jpg", ".jpeg"):
+        _embed_jpeg(path, description)
     elif suffix == ".png":
-        _embed_png(dest, description)
+        _embed_png(path, description)
     elif suffix == ".webp":
-        _embed_webp(dest, description)
+        _embed_webp(path, description)
+    elif suffix in (".tif", ".tiff"):
+        _embed_tiff(path, description)
 
 
 class Embedder:
@@ -171,14 +185,8 @@ class Embedder:
         dest.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(work_src, dest)
 
-        embed_suffix = dest.suffix.lower()
-        if embed_suffix in (".jpg", ".jpeg"):
-            _embed_jpeg(dest, description)
-        elif embed_suffix == ".png":
-            _embed_png(dest, description)
-        elif embed_suffix == ".webp":
-            _embed_webp(dest, description)
         # Other formats: copy is made but no metadata written (rare)
+        _embed_by_format(dest, description)
 
         return dest
 
@@ -411,6 +419,32 @@ def _embed_png(path: Path, description: str) -> None:
         img.save(path, "PNG", pnginfo=meta)
     except Exception as exc:
         raise RuntimeError(f"PNG embed failed for {path.name}: {exc}") from exc
+
+
+# ------------------------------------------------------------------ #
+# TIFF embedding                                                       #
+# ------------------------------------------------------------------ #
+
+def _embed_tiff(path: Path, description: str) -> None:
+    """Write ImageDescription + XPComment tags into a TIFF in place.
+
+    TIFF keeps its tags in the IFD, not in JPEG APP segments, so this cannot
+    reuse _embed_jpeg: injecting an APP1 segment overwrites the "II*\\0" magic
+    and leaves a file nothing can open. Pillow rewrites the whole file,
+    carrying over the other tags it parsed into tag_v2.
+    """
+    try:
+        from PIL import Image
+
+        img = Image.open(path)
+        ifd = img.tag_v2
+        ifd[_TIFF_IMAGE_DESCRIPTION] = description
+        # XPComment is UCS-2 with a trailing NUL — what Windows Explorer reads
+        # into its "Comments" column.
+        ifd[_TIFF_XP_COMMENT] = description.encode("utf-16-le") + b"\x00\x00"
+        img.save(path, "TIFF", tiffinfo=ifd)
+    except Exception as exc:
+        raise RuntimeError(f"TIFF embed failed for {path.name}: {exc}") from exc
 
 
 # ------------------------------------------------------------------ #

--- a/idt_core/embedder.py
+++ b/idt_core/embedder.py
@@ -434,15 +434,29 @@ def _embed_tiff(path: Path, description: str) -> None:
     carrying over the other tags it parsed into tag_v2.
     """
     try:
-        from PIL import Image
+        from PIL import Image, ImageSequence
 
         img = Image.open(path)
+
+        # Multi-page TIFF is the normal shape for scanned documents, and a plain
+        # save() keeps only the frame currently seeked. Without save_all this
+        # silently drops pages 2..N — and in-place mode drops them off the only
+        # copy. Every frame is materialised before the write, because the write
+        # goes to the file still being read.
+        frames = [frame.copy() for frame in ImageSequence.Iterator(img)]
+
+        # Read the IFD only after that iteration. seek() rewrites tag_v2 in
+        # place rather than handing back a new object, so tags set before
+        # iterating are silently wiped by the walk to the last page.
+        img.seek(0)
         ifd = img.tag_v2
         ifd[_TIFF_IMAGE_DESCRIPTION] = description
         # XPComment is UCS-2 with a trailing NUL — what Windows Explorer reads
         # into its "Comments" column.
         ifd[_TIFF_XP_COMMENT] = description.encode("utf-16-le") + b"\x00\x00"
-        img.save(path, "TIFF", tiffinfo=ifd)
+
+        extra = {"save_all": True, "append_images": frames[1:]} if len(frames) > 1 else {}
+        frames[0].save(path, "TIFF", tiffinfo=ifd, **extra)
     except Exception as exc:
         raise RuntimeError(f"TIFF embed failed for {path.name}: {exc}") from exc
 

--- a/pytest_tests/unit/test_embedded_metadata_visibility.py
+++ b/pytest_tests/unit/test_embedded_metadata_visibility.py
@@ -164,7 +164,10 @@ class TestPngVisibility:
         from PIL import Image
 
         dest = _embed(tmp_path, ".png", "PNG")
-        assert Image.open(dest).text["Description"] == DESCRIPTION
+        # Opened outside the assert: python -O strips assert statements, and a
+        # check whose only file read lives inside one silently stops running.
+        chunks = Image.open(dest).text
+        assert chunks["Description"] == DESCRIPTION
 
     def test_xmp_chunk_carries_description(self, tmp_path):
         """PNG has no EXIF, so the guide tells PNG users to use the Title column."""
@@ -305,7 +308,8 @@ class TestTiffVisibility:
         Image.new("RGB", (400, 300), (10, 20, 30)).save(src, "TIFF", compression="tiff_lzw")
         dest = tmp_path / "lzw_out.tif"
         embed_image_file(src, DESCRIPTION, dest)
-        assert Image.open(dest).info.get("compression") == "tiff_lzw"
+        info = Image.open(dest).info
+        assert info.get("compression") == "tiff_lzw"
 
     def test_pixels_are_preserved(self, tmp_path):
         """Pillow rewrites the whole file for TIFF, so check it rewrites it faithfully."""
@@ -317,7 +321,8 @@ class TestTiffVisibility:
         before = Image.open(src).tobytes()
         dest = tmp_path / "out.tif"
         embed_image_file(src, DESCRIPTION, dest)
-        assert Image.open(dest).tobytes() == before
+        after = Image.open(dest).tobytes()
+        assert after == before
 
 
 # ------------------------------------------------------------------ #
@@ -601,17 +606,17 @@ class TestMacosSpotlight:
     """
 
     def _require_or_skip(self, value, path: Path):
-        if value is not None:
-            return value
-        if os.environ.get("IDT_REQUIRE_SPOTLIGHT") == "1":
-            pytest.fail(
-                f"mdls reported nothing for {path.name}. The user guide tells "
-                "macOS readers to use exactly this command."
+        if value is None:
+            if os.environ.get("IDT_REQUIRE_SPOTLIGHT") == "1":
+                pytest.fail(
+                    f"mdls reported nothing for {path.name}. The user guide "
+                    "tells macOS readers to use exactly this command."
+                )
+            pytest.skip(
+                "Spotlight has not indexed this path (normal on CI). "
+                "Set IDT_REQUIRE_SPOTLIGHT=1 on an indexed Mac to require it."
             )
-        pytest.skip(
-            "Spotlight has not indexed this path (normal on CI). "
-            "Set IDT_REQUIRE_SPOTLIGHT=1 on an indexed Mac to require it."
-        )
+        return value
 
     def test_documented_mdls_command_returns_the_description(self, tmp_path):
         path = _embed(tmp_path, ".jpg", "JPEG")

--- a/pytest_tests/unit/test_embedded_metadata_visibility.py
+++ b/pytest_tests/unit/test_embedded_metadata_visibility.py
@@ -23,6 +23,8 @@ were routed through the JPEG writer, which injected an APP1 segment over the
 Pillow, Explorer and Preview all refused to open.
 """
 
+import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -76,8 +78,6 @@ def _read_exif_user_comment(path: Path) -> str:
 
 def _read_xmp_description(path: Path) -> str:
     """XMP dc:description — what macOS Spotlight, Preview and Photos read."""
-    import re
-
     from idt_core.embedder import _extract_xmp_from_jpeg
 
     if path.suffix.lower() in (".jpg", ".jpeg"):
@@ -329,6 +329,108 @@ class TestWindowsExplorerColumns:
     def test_tiff_appears_in_comments_column(self, tmp_path):
         columns = _explorer_columns(_embed(tmp_path, ".tif", "TIFF"))
         assert columns.get("Comments") == DESCRIPTION
+
+
+# ------------------------------------------------------------------ #
+# The macOS instructions in the user guide, checked against macOS        #
+# ------------------------------------------------------------------ #
+
+def _spotlight_attributes(path: Path) -> tuple[dict, str]:
+    """Read a file's Spotlight attributes, returning (attributes, source_tool).
+
+    `mdls` is the command the user guide gives, so it is tried first. It reads
+    the Spotlight *index*, which on a CI runner may never have seen the temp
+    directory -- a null answer there says nothing about the file.
+
+    `mdimport -t` runs the same importer directly against the file, no index
+    involved. If mdimport produces the description and mdls does not, the
+    metadata is correct and only the index is missing, so the test still passes
+    and records which tool answered.
+    """
+    attributes: dict[str, str] = {}
+
+    probe = subprocess.run(
+        ["mdls", str(path)], capture_output=True, text=True, timeout=60,
+    )
+    if probe.returncode == 0:
+        for line in probe.stdout.splitlines():
+            key, sep, value = line.partition("=")
+            if sep and value.strip() not in ("(null)", ""):
+                attributes[key.strip()] = value.strip().strip('"')
+    if attributes.get("kMDItemDescription"):
+        return attributes, "mdls"
+
+    forced = subprocess.run(
+        ["mdimport", "-t", "-d2", str(path)], capture_output=True, text=True, timeout=60,
+    )
+    combined = forced.stdout + forced.stderr
+    match = re.search(r'kMDItemDescription\s*=\s*"?(.*?)"?[;\n]', combined)
+    if match:
+        attributes["kMDItemDescription"] = match.group(1).strip()
+        return attributes, "mdimport"
+
+    if os.environ.get("IDT_REQUIRE_SPOTLIGHT") == "1":
+        pytest.fail(
+            "Neither mdls nor mdimport reported kMDItemDescription. The user "
+            "guide tells macOS readers to use exactly these tools.\n"
+            f"mdls rc={probe.returncode}\nmdimport output:\n{combined[:1000]}"
+        )
+    pytest.skip("Spotlight metadata unavailable (set IDT_REQUIRE_SPOTLIGHT=1 to fail instead)")
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS Spotlight metadata")
+class TestMacosSpotlightMetadata:
+    """The guide tells macOS readers to use Get Info, Spotlight and mdls.
+
+    All three read the same place: kMDItemDescription, which macOS populates
+    from the XMP dc:description packet the embedder writes. Asserting on that
+    key is asserting on what Get Info displays, without needing a GUI.
+    """
+
+    def test_jpeg_description_reaches_spotlight(self, tmp_path):
+        attributes, _ = _spotlight_attributes(_embed(tmp_path, ".jpg", "JPEG"))
+        assert attributes["kMDItemDescription"] == DESCRIPTION
+
+    def test_png_description_reaches_spotlight(self, tmp_path):
+        attributes, _ = _spotlight_attributes(_embed(tmp_path, ".png", "PNG"))
+        assert attributes["kMDItemDescription"] == DESCRIPTION
+
+    def test_unicode_survives_to_spotlight(self, tmp_path):
+        attributes, _ = _spotlight_attributes(
+            _embed(tmp_path, ".jpg", "JPEG", UNICODE_DESCRIPTION)
+        )
+        assert attributes["kMDItemDescription"] == UNICODE_DESCRIPTION
+
+    def test_finder_comment_is_not_where_the_description_lands(self, tmp_path):
+        """The caveat in the guide, made checkable.
+
+        Finder's "Comments" column shows kMDItemFinderComment, an xattr Finder
+        keeps on the side. Embedding must not populate it -- if it ever did, the
+        guide's warning would be wrong and readers would be told to ignore a
+        column that works.
+        """
+        attributes, _ = _spotlight_attributes(_embed(tmp_path, ".jpg", "JPEG"))
+        assert not attributes.get("kMDItemFinderComment"), (
+            "embedding wrote a Finder comment; the user guide says it does not"
+        )
+
+    def test_mdls_command_from_the_guide_runs_verbatim(self, tmp_path):
+        """The guide prints `mdls -name kMDItemDescription photo.jpg`.
+
+        Run that exact form, so a typo in the documented command is caught here
+        rather than by a reader pasting it into Terminal.
+        """
+        path = _embed(tmp_path, ".jpg", "JPEG")
+        out = subprocess.run(
+            ["mdls", "-name", "kMDItemDescription", str(path)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert out.returncode == 0, out.stderr
+        assert "kMDItemDescription" in out.stdout
+        if "(null)" in out.stdout:
+            _spotlight_attributes(path)   # skips or fails with the fuller diagnosis
+        else:
+            assert DESCRIPTION in out.stdout
 
 
 # ------------------------------------------------------------------ #

--- a/pytest_tests/unit/test_embedded_metadata_visibility.py
+++ b/pytest_tests/unit/test_embedded_metadata_visibility.py
@@ -411,7 +411,23 @@ class TestWindowsExplorerColumns:
         assert columns.get("Title") == DESCRIPTION
 
     def test_webp_appears_in_comments_column(self, tmp_path):
+        """WebP needs a codec Windows does not always ship.
+
+        Explorer reads WebP properties through the Microsoft WebP Image
+        Extension. Windows 11 desktop installs have it; Server images and CI
+        runners do not, and without it the shell has no property handler for
+        .webp at all — every image column comes back empty, not just Comments.
+
+        Distinguish the two: no Dimensions means no handler, which is a fact
+        about the machine. Dimensions but no Comments means the embed is broken.
+        """
         columns = _explorer_columns(_embed(tmp_path, ".webp", "WEBP"))
+        if not columns.get("Dimensions"):
+            pytest.skip(
+                "no WebP property handler on this machine (Microsoft WebP Image "
+                "Extension not installed) — Explorer shows no WebP image "
+                "columns at all, so Comments cannot be checked"
+            )
         assert columns.get("Comments") == DESCRIPTION
 
     def test_tiff_appears_in_comments_column(self, tmp_path):

--- a/pytest_tests/unit/test_embedded_metadata_visibility.py
+++ b/pytest_tests/unit/test_embedded_metadata_visibility.py
@@ -1,0 +1,369 @@
+"""What an embedded description looks like from outside IDT.
+
+The existing embedder tests in test_idt_core.py prove the copies get made, land
+in the right directory and carry XMP. They stop there. But the promise the user
+guide makes is a different one: turn on the Comments column in File Explorer and
+the description is sitting there; press Cmd+I in Finder and it is sitting there.
+That promise rests on *which specific tag* each format gets, and nothing pinned
+those tags down.
+
+So these tests read the files back the way the operating system does:
+
+  Windows Explorer "Comments"  ← EXIF UserComment (JPEG, WebP) / XPComment (TIFF)
+  Windows Explorer "Title"     ← XMP dc:description (JPEG, PNG) / ImageDescription (TIFF)
+  macOS Get Info / Spotlight   ← XMP dc:description
+  Apple Photos caption         ← XMP dc:description
+
+Change a tag number here and a documented, screen-reader-accessible way of
+getting at these descriptions quietly stops working, with no error anywhere.
+
+The TIFF cases are a regression guard. Until this file existed, .tif and .tiff
+were routed through the JPEG writer, which injected an APP1 segment over the
+"II*\0" magic. The result was not a TIFF without a description; it was a file
+Pillow, Explorer and Preview all refused to open.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(_ROOT))
+
+pytestmark = pytest.mark.unit
+
+DESCRIPTION = "A tabby cat asleep on a sunlit windowsill."
+UNICODE_DESCRIPTION = "Un café à Paris — 15° et « nuageux », 日本語も"
+
+
+# ------------------------------------------------------------------ #
+# Fixtures                                                             #
+# ------------------------------------------------------------------ #
+
+def _write_source(path: Path, fmt: str) -> Path:
+    """Save a small real image so the format writers have something to chew on."""
+    from PIL import Image
+
+    Image.new("RGB", (32, 24), (120, 60, 30)).save(path, fmt)
+    return path
+
+
+def _embed(tmp_path: Path, suffix: str, fmt: str, text: str = DESCRIPTION) -> Path:
+    from idt_core.embedder import embed_image_file
+
+    src = _write_source(tmp_path / f"src{suffix}", fmt)
+    dest = tmp_path / f"embedded{suffix}"
+    embed_image_file(src, text, dest)
+    return dest
+
+
+# ------------------------------------------------------------------ #
+# Readers that mimic what each platform actually looks at               #
+# ------------------------------------------------------------------ #
+
+def _read_exif_user_comment(path: Path) -> str:
+    """EXIF UserComment — the tag behind Explorer's "Comments" column."""
+    import piexif
+    import piexif.helper
+
+    exif = piexif.load(str(path))
+    raw = exif["Exif"].get(piexif.ExifIFD.UserComment)
+    assert raw is not None, f"{path.name} has no EXIF UserComment"
+    return piexif.helper.UserComment.load(raw)
+
+
+def _read_xmp_description(path: Path) -> str:
+    """XMP dc:description — what macOS Spotlight, Preview and Photos read."""
+    import re
+
+    from idt_core.embedder import _extract_xmp_from_jpeg
+
+    if path.suffix.lower() in (".jpg", ".jpeg"):
+        payload = _extract_xmp_from_jpeg(path.read_bytes())
+        assert payload is not None, f"{path.name} has no XMP APP1 segment"
+        xmp = payload.decode("utf-8", errors="replace")
+    else:
+        from PIL import Image
+
+        xmp = (getattr(Image.open(path), "text", {}) or {}).get("XML:com.adobe.xmp", "")
+        assert xmp, f"{path.name} has no XMP chunk"
+
+    match = re.search(r'<rdf:li[^>]*x-default"?[^>]*>(.*?)</rdf:li>', xmp, re.DOTALL)
+    assert match, f"{path.name} XMP has no x-default rdf:li:\n{xmp}"
+    return match.group(1).strip()
+
+
+def _read_tiff_tag(path: Path, tag: int):
+    from PIL import Image
+
+    return Image.open(path).tag_v2.get(tag)
+
+
+def _still_opens(path: Path) -> None:
+    """A file with metadata nothing can read is a bug; a file nothing can open is worse."""
+    from PIL import Image
+
+    img = Image.open(path)
+    img.load()
+
+
+# ------------------------------------------------------------------ #
+# JPEG — both Windows columns and the macOS fields                      #
+# ------------------------------------------------------------------ #
+
+class TestJpegVisibility:
+    def test_user_comment_carries_description(self, tmp_path):
+        """Explorer's "Comments" column reads EXIF UserComment."""
+        dest = _embed(tmp_path, ".jpg", "JPEG")
+        assert _read_exif_user_comment(dest) == DESCRIPTION
+
+    def test_xmp_description_carries_description(self, tmp_path):
+        """Finder Get Info, Spotlight and Photos all read XMP dc:description."""
+        dest = _embed(tmp_path, ".jpg", "JPEG")
+        assert _read_xmp_description(dest) == DESCRIPTION
+
+    def test_both_fields_agree(self, tmp_path):
+        """Windows and macOS users must not be shown two different descriptions."""
+        dest = _embed(tmp_path, ".jpg", "JPEG")
+        assert _read_exif_user_comment(dest) == _read_xmp_description(dest)
+
+    def test_file_still_opens(self, tmp_path):
+        _still_opens(_embed(tmp_path, ".jpg", "JPEG"))
+
+    def test_unicode_survives_both_fields(self, tmp_path):
+        """UserComment is dumped as UCS-2 and XMP as UTF-8 — neither may mangle accents."""
+        dest = _embed(tmp_path, ".jpg", "JPEG", UNICODE_DESCRIPTION)
+        assert _read_exif_user_comment(dest) == UNICODE_DESCRIPTION
+        assert _read_xmp_description(dest) == UNICODE_DESCRIPTION
+
+
+# ------------------------------------------------------------------ #
+# PNG — no EXIF, so XMP and tEXt are the whole story                    #
+# ------------------------------------------------------------------ #
+
+class TestPngVisibility:
+    def test_text_chunk_carries_description(self, tmp_path):
+        from PIL import Image
+
+        dest = _embed(tmp_path, ".png", "PNG")
+        assert Image.open(dest).text["Description"] == DESCRIPTION
+
+    def test_xmp_chunk_carries_description(self, tmp_path):
+        """PNG has no EXIF, so the guide tells PNG users to use the Title column."""
+        dest = _embed(tmp_path, ".png", "PNG")
+        assert _read_xmp_description(dest) == DESCRIPTION
+
+    def test_file_still_opens(self, tmp_path):
+        _still_opens(_embed(tmp_path, ".png", "PNG"))
+
+    def test_unicode_survives(self, tmp_path):
+        dest = _embed(tmp_path, ".png", "PNG", UNICODE_DESCRIPTION)
+        assert _read_xmp_description(dest) == UNICODE_DESCRIPTION
+
+
+# ------------------------------------------------------------------ #
+# WebP — EXIF only                                                      #
+# ------------------------------------------------------------------ #
+
+class TestWebpVisibility:
+    def test_user_comment_carries_description(self, tmp_path):
+        dest = _embed(tmp_path, ".webp", "WEBP")
+        assert _read_exif_user_comment(dest) == DESCRIPTION
+
+    def test_file_still_opens(self, tmp_path):
+        _still_opens(_embed(tmp_path, ".webp", "WEBP"))
+
+    def test_unicode_survives(self, tmp_path):
+        dest = _embed(tmp_path, ".webp", "WEBP", UNICODE_DESCRIPTION)
+        assert _read_exif_user_comment(dest) == UNICODE_DESCRIPTION
+
+
+# ------------------------------------------------------------------ #
+# TIFF — the regression that started this file                          #
+# ------------------------------------------------------------------ #
+
+class TestTiffVisibility:
+    @pytest.mark.regression
+    def test_embedded_tiff_is_still_a_readable_tiff(self, tmp_path):
+        """.tif used to be handed to the JPEG writer, which destroyed the file."""
+        dest = _embed(tmp_path, ".tif", "TIFF")
+        assert dest.read_bytes()[:2] in (b"II", b"MM"), "TIFF byte-order magic overwritten"
+        _still_opens(dest)
+
+    @pytest.mark.regression
+    def test_tiff_extension_also_handled(self, tmp_path):
+        """Both spellings route to the TIFF writer, not just .tif."""
+        dest = _embed(tmp_path, ".tiff", "TIFF")
+        _still_opens(dest)
+        from idt_core.embedder import _TIFF_IMAGE_DESCRIPTION
+
+        assert _read_tiff_tag(dest, _TIFF_IMAGE_DESCRIPTION) == DESCRIPTION
+
+    def test_image_description_tag_carries_description(self, tmp_path):
+        """Tag 270 feeds Explorer's Title and Subject columns."""
+        from idt_core.embedder import _TIFF_IMAGE_DESCRIPTION
+
+        dest = _embed(tmp_path, ".tif", "TIFF")
+        assert _read_tiff_tag(dest, _TIFF_IMAGE_DESCRIPTION) == DESCRIPTION
+
+    def test_xp_comment_tag_carries_description(self, tmp_path):
+        """Tag 40092 is UCS-2 with a trailing NUL, and feeds the Comments column."""
+        from idt_core.embedder import _TIFF_XP_COMMENT
+
+        dest = _embed(tmp_path, ".tif", "TIFF")
+        raw = _read_tiff_tag(dest, _TIFF_XP_COMMENT)
+        assert raw is not None, "no XPComment tag — Explorer's Comments column stays empty"
+        if isinstance(raw, (tuple, list)):
+            raw = bytes(raw)
+        assert raw.decode("utf-16-le").rstrip("\x00") == DESCRIPTION
+
+    def test_pixels_are_preserved(self, tmp_path):
+        """Pillow rewrites the whole file for TIFF, so check it rewrites it faithfully."""
+        from PIL import Image
+
+        from idt_core.embedder import embed_image_file
+
+        src = _write_source(tmp_path / "src.tif", "TIFF")
+        before = Image.open(src).tobytes()
+        dest = tmp_path / "out.tif"
+        embed_image_file(src, DESCRIPTION, dest)
+        assert Image.open(dest).tobytes() == before
+
+
+# ------------------------------------------------------------------ #
+# Format dispatch                                                       #
+# ------------------------------------------------------------------ #
+
+class TestFormatDispatch:
+    def test_unknown_format_is_copied_not_corrupted(self, tmp_path):
+        """An unsupported extension gets a plain copy — never a speculative write."""
+        from idt_core.embedder import embed_image_file
+
+        src = tmp_path / "notes.bmp"
+        _write_source(src, "BMP")
+        original = src.read_bytes()
+        dest = tmp_path / "out.bmp"
+        embed_image_file(src, DESCRIPTION, dest)
+        assert dest.read_bytes() == original
+
+    @pytest.mark.parametrize("suffix,fmt", [
+        (".jpg", "JPEG"), (".png", "PNG"), (".webp", "WEBP"), (".tif", "TIFF"),
+    ])
+    def test_source_is_never_touched(self, tmp_path, suffix, fmt):
+        from idt_core.embedder import embed_image_file
+
+        src = _write_source(tmp_path / f"src{suffix}", fmt)
+        before = src.read_bytes()
+        embed_image_file(src, DESCRIPTION, tmp_path / f"out{suffix}")
+        assert src.read_bytes() == before
+
+    @pytest.mark.parametrize("suffix,fmt", [
+        (".jpg", "JPEG"), (".png", "PNG"), (".webp", "WEBP"), (".tif", "TIFF"),
+    ])
+    def test_in_place_mode_keeps_the_file_openable(self, tmp_path, suffix, fmt):
+        from idt_core.embedder import embed_image_file
+
+        path = _write_source(tmp_path / f"inplace{suffix}", fmt)
+        embed_image_file(path, DESCRIPTION, path)
+        _still_opens(path)
+
+
+# ------------------------------------------------------------------ #
+# The Windows instructions in the user guide, checked against Windows    #
+# ------------------------------------------------------------------ #
+
+def _explorer_columns(path: Path) -> dict:
+    """Ask the Windows shell for the same column values Explorer would display."""
+    script = f"""
+$sh = New-Object -ComObject Shell.Application
+$f = $sh.NameSpace('{path.parent}')
+$item = $f.ParseName('{path.name}')
+foreach ($i in 0..40) {{
+  $col = $f.GetDetailsOf($f.Items, $i)
+  $val = $f.GetDetailsOf($item, $i)
+  if ($col -and $val) {{ Write-Output ($col + '=' + $val) }}
+}}
+"""
+    out = subprocess.run(
+        ["powershell", "-NoProfile", "-NonInteractive", "-Command", script],
+        capture_output=True, text=True, timeout=90,
+    )
+    if out.returncode != 0:
+        pytest.skip(f"Windows shell query unavailable: {out.stderr.strip()[:200]}")
+    columns = {}
+    for line in out.stdout.splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            columns[key.strip()] = value.strip()
+    return columns
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows Explorer columns")
+class TestWindowsExplorerColumns:
+    """The user guide tells Windows users to switch on a specific column.
+
+    These tests query the shell property system directly, so if a future change
+    to the tags leaves that column blank, the guide is wrong and CI says so
+    rather than a reader discovering it in Explorer.
+    """
+
+    def test_jpeg_appears_in_comments_column(self, tmp_path):
+        columns = _explorer_columns(_embed(tmp_path, ".jpg", "JPEG"))
+        assert columns.get("Comments") == DESCRIPTION
+
+    def test_jpeg_appears_in_title_column(self, tmp_path):
+        columns = _explorer_columns(_embed(tmp_path, ".jpg", "JPEG"))
+        assert columns.get("Title") == DESCRIPTION
+
+    def test_png_appears_in_title_column(self, tmp_path):
+        """PNG has no EXIF, so Title is the only column that works — as documented."""
+        columns = _explorer_columns(_embed(tmp_path, ".png", "PNG"))
+        assert columns.get("Title") == DESCRIPTION
+
+    def test_webp_appears_in_comments_column(self, tmp_path):
+        columns = _explorer_columns(_embed(tmp_path, ".webp", "WEBP"))
+        assert columns.get("Comments") == DESCRIPTION
+
+    def test_tiff_appears_in_comments_column(self, tmp_path):
+        columns = _explorer_columns(_embed(tmp_path, ".tif", "TIFF"))
+        assert columns.get("Comments") == DESCRIPTION
+
+
+# ------------------------------------------------------------------ #
+# The guide itself                                                      #
+# ------------------------------------------------------------------ #
+
+class TestUserGuideDocumentsAccess:
+    """The feature is only useful if people can find the descriptions again.
+
+    Embedding shipped before the guide said how to read the result back, which
+    is how this whole exercise started. These assertions keep the instructions
+    in place, so a future edit cannot quietly drop them.
+    """
+
+    @property
+    def _guide(self) -> str:
+        return (_ROOT / "docs" / "USER_GUIDE.md").read_text(encoding="utf-8")
+
+    def test_guide_exists(self):
+        assert (_ROOT / "docs" / "USER_GUIDE.md").is_file()
+
+    def test_windows_steps_are_documented(self):
+        guide = self._guide
+        for needle in ("Details view", "Shift+F10", "Comments"):
+            assert needle in guide, f"Windows access instructions lost {needle!r}"
+
+    def test_macos_steps_are_documented(self):
+        guide = self._guide
+        assert "Get Info" in guide, "macOS access instructions lost Get Info"
+        assert "mdls" in guide, "macOS access instructions lost the mdls fallback"
+
+    def test_finder_comments_caveat_is_documented(self):
+        """Finder's Comments column is a Spotlight xattr, not embedded metadata.
+
+        Readers who switch it on and see nothing need to know why, or they will
+        conclude the embed failed.
+        """
+        assert "Spotlight Comments" in self._guide

--- a/pytest_tests/unit/test_embedded_metadata_visibility.py
+++ b/pytest_tests/unit/test_embedded_metadata_visibility.py
@@ -101,6 +101,21 @@ def _read_tiff_tag(path: Path, tag: int):
     return Image.open(path).tag_v2.get(tag)
 
 
+def _page_count(path: Path) -> int:
+    """Number of frames in a multi-page image."""
+    from PIL import Image
+
+    img = Image.open(path)
+    count = 0
+    try:
+        while True:
+            img.seek(count)
+            count += 1
+    except EOFError:
+        pass
+    return count
+
+
 def _still_opens(path: Path) -> None:
     """A file with metadata nothing can read is a bug; a file nothing can open is worse."""
     from PIL import Image
@@ -219,6 +234,78 @@ class TestTiffVisibility:
             raw = bytes(raw)
         assert raw.decode("utf-16-le").rstrip("\x00") == DESCRIPTION
 
+    @pytest.mark.regression
+    def test_multipage_tiff_keeps_every_page(self, tmp_path):
+        """Scanned documents are multi-page, and a plain save() keeps only one.
+
+        Pillow's save() writes the frame currently seeked unless save_all is
+        passed, so a four-page scan came back as one page with no error raised.
+        In-place mode overwrites the only copy, making it unrecoverable.
+        """
+        from PIL import Image
+
+        from idt_core.embedder import embed_image_file
+
+        colours = [(255, 0, 0), (0, 255, 0), (0, 0, 255), (255, 255, 0)]
+        pages = [Image.new("RGB", (40, 30), c) for c in colours]
+        src = tmp_path / "scan.tif"
+        pages[0].save(src, "TIFF", save_all=True, append_images=pages[1:])
+
+        dest = tmp_path / "scan_out.tif"
+        embed_image_file(src, DESCRIPTION, dest)
+
+        assert _page_count(dest) == 4, "pages were dropped"
+        out = Image.open(dest)
+        for index, colour in enumerate(colours):
+            out.seek(index)
+            assert out.convert("RGB").getpixel((5, 5)) == colour, f"page {index} wrong"
+
+    @pytest.mark.regression
+    def test_multipage_tiff_still_gets_the_description(self, tmp_path):
+        """The page fix must not cost the description.
+
+        `seek()` rewrites tag_v2 in place rather than returning a new object, so
+        setting the tags before walking the frames left them wiped by the time
+        of the save — pages preserved, description silently gone.
+        """
+        from PIL import Image
+
+        from idt_core.embedder import embed_image_file, _TIFF_IMAGE_DESCRIPTION
+
+        pages = [Image.new("RGB", (20, 20), c) for c in [(1, 2, 3), (4, 5, 6)]]
+        src = tmp_path / "two.tif"
+        pages[0].save(src, "TIFF", save_all=True, append_images=pages[1:])
+
+        dest = tmp_path / "two_out.tif"
+        embed_image_file(src, DESCRIPTION, dest)
+        assert _read_tiff_tag(dest, _TIFF_IMAGE_DESCRIPTION) == DESCRIPTION
+
+    @pytest.mark.regression
+    def test_multipage_tiff_in_place_keeps_pages(self, tmp_path):
+        """In-place mode is where page loss is unrecoverable — no copy to fall back on."""
+        from PIL import Image
+
+        from idt_core.embedder import embed_image_file
+
+        pages = [Image.new("RGB", (20, 20), c) for c in [(1, 2, 3), (4, 5, 6), (7, 8, 9)]]
+        path = tmp_path / "inplace_multi.tif"
+        pages[0].save(path, "TIFF", save_all=True, append_images=pages[1:])
+
+        embed_image_file(path, DESCRIPTION, path)
+        assert _page_count(path) == 3
+
+    def test_compression_is_not_silently_dropped(self, tmp_path):
+        """Rewriting the file must not turn an LZW archive into an uncompressed one."""
+        from PIL import Image
+
+        from idt_core.embedder import embed_image_file
+
+        src = tmp_path / "lzw.tif"
+        Image.new("RGB", (400, 300), (10, 20, 30)).save(src, "TIFF", compression="tiff_lzw")
+        dest = tmp_path / "lzw_out.tif"
+        embed_image_file(src, DESCRIPTION, dest)
+        assert Image.open(dest).info.get("compression") == "tiff_lzw"
+
     def test_pixels_are_preserved(self, tmp_path):
         """Pillow rewrites the whole file for TIFF, so check it rewrites it faithfully."""
         from PIL import Image
@@ -334,103 +421,160 @@ class TestWindowsExplorerColumns:
 # ------------------------------------------------------------------ #
 # The macOS instructions in the user guide, checked against macOS        #
 # ------------------------------------------------------------------ #
+#
+# Three different readers, because they fail in different ways:
+#
+#   xattr     — Finder comments are an extended attribute. No index, no
+#               framework, works on any Mac including a bare CI runner.
+#   ImageIO   — the framework Preview, Get Info and the Spotlight importer all
+#               sit on. Needs pyobjc but no running daemon.
+#   Spotlight — mdls, the command printed in the guide. Needs an indexed
+#               volume, which GitHub's runners do not have.
+#
+# Only the last one is allowed to skip.
 
-def _spotlight_attributes(path: Path) -> tuple[dict, str]:
-    """Read a file's Spotlight attributes, returning (attributes, source_tool).
+_FINDER_COMMENT_XATTR = "com.apple.metadata:kMDItemFinderComment"
 
-    `mdls` is the command the user guide gives, so it is tried first. It reads
-    the Spotlight *index*, which on a CI runner may never have seen the temp
-    directory -- a null answer there says nothing about the file.
 
-    `mdimport -t` runs the same importer directly against the file, no index
-    involved. If mdimport produces the description and mdls does not, the
-    metadata is correct and only the index is missing, so the test still passes
-    and records which tool answered.
-    """
-    attributes: dict[str, str] = {}
-
-    probe = subprocess.run(
-        ["mdls", str(path)], capture_output=True, text=True, timeout=60,
+def _imageio_properties(path: Path) -> dict:
+    """Read image metadata through ImageIO, the way macOS's own viewers do."""
+    Quartz = pytest.importorskip(
+        "Quartz", reason="pyobjc-framework-Quartz not installed",
     )
-    if probe.returncode == 0:
-        for line in probe.stdout.splitlines():
-            key, sep, value = line.partition("=")
-            if sep and value.strip() not in ("(null)", ""):
-                attributes[key.strip()] = value.strip().strip('"')
-    if attributes.get("kMDItemDescription"):
-        return attributes, "mdls"
+    from CoreFoundation import CFURLCreateFromFileSystemRepresentation
 
-    forced = subprocess.run(
-        ["mdimport", "-t", "-d2", str(path)], capture_output=True, text=True, timeout=60,
+    url = CFURLCreateFromFileSystemRepresentation(
+        None, str(path).encode("utf-8"), len(str(path).encode("utf-8")), False,
     )
-    combined = forced.stdout + forced.stderr
-    match = re.search(r'kMDItemDescription\s*=\s*"?(.*?)"?[;\n]', combined)
-    if match:
-        attributes["kMDItemDescription"] = match.group(1).strip()
-        return attributes, "mdimport"
-
-    if os.environ.get("IDT_REQUIRE_SPOTLIGHT") == "1":
-        pytest.fail(
-            "Neither mdls nor mdimport reported kMDItemDescription. The user "
-            "guide tells macOS readers to use exactly these tools.\n"
-            f"mdls rc={probe.returncode}\nmdimport output:\n{combined[:1000]}"
-        )
-    pytest.skip("Spotlight metadata unavailable (set IDT_REQUIRE_SPOTLIGHT=1 to fail instead)")
+    source = Quartz.CGImageSourceCreateWithURL(url, None)
+    assert source is not None, f"ImageIO could not open {path.name}"
+    properties = Quartz.CGImageSourceCopyPropertiesAtIndex(source, 0, None)
+    assert properties is not None, f"ImageIO returned no properties for {path.name}"
+    return dict(properties)
 
 
-@pytest.mark.skipif(sys.platform != "darwin", reason="macOS Spotlight metadata")
-class TestMacosSpotlightMetadata:
-    """The guide tells macOS readers to use Get Info, Spotlight and mdls.
+def _spotlight_description(path: Path):
+    """Return what `mdls` reports, or None if Spotlight has nothing to say.
 
-    All three read the same place: kMDItemDescription, which macOS populates
-    from the XMP dc:description packet the embedder writes. Asserting on that
-    key is asserting on what Get Info displays, without needing a GUI.
+    mdls reads the Spotlight *index*. A CI runner never indexes its temp
+    directories, so a null answer there is a fact about the machine and not
+    about the file — hence None rather than a failure.
+    """
+    out = subprocess.run(
+        ["mdls", "-name", "kMDItemDescription", str(path)],
+        capture_output=True, text=True, timeout=60,
+    )
+    if out.returncode != 0 or "(null)" in out.stdout:
+        return None
+    _, sep, value = out.stdout.partition("=")
+    return value.strip().strip('"') if sep else None
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS metadata")
+class TestMacosFinderCommentCaveat:
+    """The guide warns that Finder's Comments column is not the description.
+
+    Finder comments live in an extended attribute, so this needs no Spotlight
+    index and no framework — it runs anywhere, including a bare CI runner.
     """
 
-    def test_jpeg_description_reaches_spotlight(self, tmp_path):
-        attributes, _ = _spotlight_attributes(_embed(tmp_path, ".jpg", "JPEG"))
-        assert attributes["kMDItemDescription"] == DESCRIPTION
+    def test_embedding_writes_no_finder_comment(self, tmp_path):
+        """If embedding ever populated this, the guide's warning would be wrong.
 
-    def test_png_description_reaches_spotlight(self, tmp_path):
-        attributes, _ = _spotlight_attributes(_embed(tmp_path, ".png", "PNG"))
-        assert attributes["kMDItemDescription"] == DESCRIPTION
-
-    def test_unicode_survives_to_spotlight(self, tmp_path):
-        attributes, _ = _spotlight_attributes(
-            _embed(tmp_path, ".jpg", "JPEG", UNICODE_DESCRIPTION)
-        )
-        assert attributes["kMDItemDescription"] == UNICODE_DESCRIPTION
-
-    def test_finder_comment_is_not_where_the_description_lands(self, tmp_path):
-        """The caveat in the guide, made checkable.
-
-        Finder's "Comments" column shows kMDItemFinderComment, an xattr Finder
-        keeps on the side. Embedding must not populate it -- if it ever did, the
-        guide's warning would be wrong and readers would be told to ignore a
-        column that works.
-        """
-        attributes, _ = _spotlight_attributes(_embed(tmp_path, ".jpg", "JPEG"))
-        assert not attributes.get("kMDItemFinderComment"), (
-            "embedding wrote a Finder comment; the user guide says it does not"
-        )
-
-    def test_mdls_command_from_the_guide_runs_verbatim(self, tmp_path):
-        """The guide prints `mdls -name kMDItemDescription photo.jpg`.
-
-        Run that exact form, so a typo in the documented command is caught here
-        rather than by a reader pasting it into Terminal.
+        Readers would then be told to ignore a column that actually works.
         """
         path = _embed(tmp_path, ".jpg", "JPEG")
         out = subprocess.run(
-            ["mdls", "-name", "kMDItemDescription", str(path)],
-            capture_output=True, text=True, timeout=60,
+            ["xattr", "-p", _FINDER_COMMENT_XATTR, str(path)],
+            capture_output=True, text=True, timeout=30,
         )
-        assert out.returncode == 0, out.stderr
-        assert "kMDItemDescription" in out.stdout
-        if "(null)" in out.stdout:
-            _spotlight_attributes(path)   # skips or fails with the fuller diagnosis
-        else:
-            assert DESCRIPTION in out.stdout
+        assert out.returncode != 0, (
+            f"embedding set a Finder comment ({out.stdout.strip()}); the user "
+            "guide says Finder's Comments column stays empty"
+        )
+
+    def test_the_xattr_probe_can_actually_detect_one(self, tmp_path):
+        """Guard against the assertion above passing because the probe is broken.
+
+        A test that checks for absence proves nothing unless presence is
+        detectable — so set a comment by hand and confirm it is seen.
+        """
+        path = _embed(tmp_path, ".jpg", "JPEG")
+        written = subprocess.run(
+            ["xattr", "-w", _FINDER_COMMENT_XATTR, "a hand-written note", str(path)],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert written.returncode == 0, f"could not set xattr: {written.stderr}"
+        out = subprocess.run(
+            ["xattr", "-p", _FINDER_COMMENT_XATTR, str(path)],
+            capture_output=True, text=True, timeout=30,
+        )
+        assert out.returncode == 0 and "hand-written" in out.stdout
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS ImageIO")
+class TestMacosImageIoMetadata:
+    """Get Info, Preview and the Spotlight importer all read through ImageIO.
+
+    Querying it directly is the closest thing to opening Get Info that a
+    headless runner can do, and unlike mdls it needs no indexed volume.
+    """
+
+    def test_jpeg_description_is_visible_to_imageio(self, tmp_path):
+        properties = _imageio_properties(_embed(tmp_path, ".jpg", "JPEG"))
+        rendered = str(properties)
+        assert DESCRIPTION in rendered, (
+            "macOS's own image framework cannot see the description:\n"
+            f"{rendered[:2000]}"
+        )
+
+    def test_tiff_description_is_visible_to_imageio(self, tmp_path):
+        """TIFF gets IFD tags and no XMP, so it needs checking separately."""
+        properties = _imageio_properties(_embed(tmp_path, ".tif", "TIFF"))
+        assert DESCRIPTION in str(properties)
+
+    def test_png_description_is_visible_to_imageio(self, tmp_path):
+        properties = _imageio_properties(_embed(tmp_path, ".png", "PNG"))
+        assert DESCRIPTION in str(properties)
+
+    def test_unicode_survives_to_imageio(self, tmp_path):
+        properties = _imageio_properties(
+            _embed(tmp_path, ".jpg", "JPEG", UNICODE_DESCRIPTION)
+        )
+        assert UNICODE_DESCRIPTION in str(properties)
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="macOS Spotlight")
+class TestMacosSpotlight:
+    """The `mdls` command the guide prints, run verbatim.
+
+    This is the one reader allowed to skip: it depends on an indexed volume,
+    and GitHub's macOS runners index nothing. Set IDT_REQUIRE_SPOTLIGHT=1 on a
+    real Mac to turn the skip into a failure.
+    """
+
+    def _require_or_skip(self, value, path: Path):
+        if value is not None:
+            return value
+        if os.environ.get("IDT_REQUIRE_SPOTLIGHT") == "1":
+            pytest.fail(
+                f"mdls reported nothing for {path.name}. The user guide tells "
+                "macOS readers to use exactly this command."
+            )
+        pytest.skip(
+            "Spotlight has not indexed this path (normal on CI). "
+            "Set IDT_REQUIRE_SPOTLIGHT=1 on an indexed Mac to require it."
+        )
+
+    def test_documented_mdls_command_returns_the_description(self, tmp_path):
+        path = _embed(tmp_path, ".jpg", "JPEG")
+        value = self._require_or_skip(_spotlight_description(path), path)
+        assert value == DESCRIPTION
+
+    def test_png_description_reaches_spotlight(self, tmp_path):
+        path = _embed(tmp_path, ".png", "PNG")
+        value = self._require_or_skip(_spotlight_description(path), path)
+        assert value == DESCRIPTION
 
 
 # ------------------------------------------------------------------ #

--- a/pytest_tests/unit/test_embedded_metadata_visibility.py
+++ b/pytest_tests/unit/test_embedded_metadata_visibility.py
@@ -11,8 +11,9 @@ So these tests read the files back the way the operating system does:
 
   Windows Explorer "Comments"  ← EXIF UserComment (JPEG, WebP) / XPComment (TIFF)
   Windows Explorer "Title"     ← XMP dc:description (JPEG, PNG) / ImageDescription (TIFF)
-  macOS Get Info / Spotlight   ← XMP dc:description
-  Apple Photos caption         ← XMP dc:description
+  macOS Get Info / Preview     ← ImageIO, which reports the description as IPTC
+                                 Caption/Abstract and EXIF UserComment
+  macOS Spotlight, mdls        ← kMDItemDescription, off the same importer
 
 Change a tag number here and a documented, screen-reader-accessible way of
 getting at these descriptions quietly stops working, with no error anywhere.
@@ -436,21 +437,40 @@ class TestWindowsExplorerColumns:
 _FINDER_COMMENT_XATTR = "com.apple.metadata:kMDItemFinderComment"
 
 
-def _imageio_properties(path: Path) -> dict:
-    """Read image metadata through ImageIO, the way macOS's own viewers do."""
+def _imageio_descriptions(path: Path) -> dict:
+    """Return the description-bearing fields macOS's own image framework reports.
+
+    Get Info, Preview and the Spotlight importer all read through ImageIO, so
+    these are the values a reader following the guide ends up looking at.
+
+    The individual fields are pulled out rather than matching against str() of
+    the whole dictionary: an NSDictionary renders non-ASCII escaped, so a
+    stringified compare fails on accented text that is in fact stored correctly.
+    """
     Quartz = pytest.importorskip(
         "Quartz", reason="pyobjc-framework-Quartz not installed",
     )
     from CoreFoundation import CFURLCreateFromFileSystemRepresentation
 
-    url = CFURLCreateFromFileSystemRepresentation(
-        None, str(path).encode("utf-8"), len(str(path).encode("utf-8")), False,
-    )
+    encoded = str(path).encode("utf-8")
+    url = CFURLCreateFromFileSystemRepresentation(None, encoded, len(encoded), False)
     source = Quartz.CGImageSourceCreateWithURL(url, None)
     assert source is not None, f"ImageIO could not open {path.name}"
     properties = Quartz.CGImageSourceCopyPropertiesAtIndex(source, 0, None)
     assert properties is not None, f"ImageIO returned no properties for {path.name}"
-    return dict(properties)
+
+    wanted = {
+        "iptc_caption": ("{IPTC}", "Caption/Abstract"),
+        "exif_user_comment": ("{Exif}", "UserComment"),
+        "tiff_image_description": ("{TIFF}", "ImageDescription"),
+        "png_description": ("{PNG}", "Description"),
+    }
+    found = {}
+    for name, (section, key) in wanted.items():
+        value = (properties.get(section) or {}).get(key)
+        if value:
+            found[name] = str(value)
+    return found
 
 
 def _spotlight_description(path: Path):
@@ -518,30 +538,41 @@ class TestMacosImageIoMetadata:
 
     Querying it directly is the closest thing to opening Get Info that a
     headless runner can do, and unlike mdls it needs no indexed volume.
+
+    Measured on macos-latest: JPEG comes back as both IPTC Caption/Abstract and
+    EXIF UserComment, and PNG and TIFF are visible too. Asserting that at least
+    one recognised field holds the exact text keeps the check honest across
+    formats without pinning macOS's internal choice of field.
     """
 
-    def test_jpeg_description_is_visible_to_imageio(self, tmp_path):
-        properties = _imageio_properties(_embed(tmp_path, ".jpg", "JPEG"))
-        rendered = str(properties)
-        assert DESCRIPTION in rendered, (
-            "macOS's own image framework cannot see the description:\n"
-            f"{rendered[:2000]}"
+    def _assert_visible(self, path: Path, expected: str) -> None:
+        found = _imageio_descriptions(path)
+        assert found, (
+            f"macOS's image framework reports no description at all for "
+            f"{path.name} — Get Info would be empty"
         )
+        assert expected in found.values(), (
+            f"no ImageIO field holds the description for {path.name}: {found}"
+        )
+
+    def test_jpeg_description_is_visible_to_imageio(self, tmp_path):
+        self._assert_visible(_embed(tmp_path, ".jpg", "JPEG"), DESCRIPTION)
 
     def test_tiff_description_is_visible_to_imageio(self, tmp_path):
         """TIFF gets IFD tags and no XMP, so it needs checking separately."""
-        properties = _imageio_properties(_embed(tmp_path, ".tif", "TIFF"))
-        assert DESCRIPTION in str(properties)
+        self._assert_visible(_embed(tmp_path, ".tif", "TIFF"), DESCRIPTION)
 
     def test_png_description_is_visible_to_imageio(self, tmp_path):
-        properties = _imageio_properties(_embed(tmp_path, ".png", "PNG"))
-        assert DESCRIPTION in str(properties)
+        self._assert_visible(_embed(tmp_path, ".png", "PNG"), DESCRIPTION)
+
+    def test_webp_description_is_visible_to_imageio(self, tmp_path):
+        self._assert_visible(_embed(tmp_path, ".webp", "WEBP"), DESCRIPTION)
 
     def test_unicode_survives_to_imageio(self, tmp_path):
-        properties = _imageio_properties(
-            _embed(tmp_path, ".jpg", "JPEG", UNICODE_DESCRIPTION)
+        """Accents and CJK must arrive intact, not mojibake in Get Info."""
+        self._assert_visible(
+            _embed(tmp_path, ".jpg", "JPEG", UNICODE_DESCRIPTION), UNICODE_DESCRIPTION
         )
-        assert UNICODE_DESCRIPTION in str(properties)
 
 
 @pytest.mark.skipif(sys.platform != "darwin", reason="macOS Spotlight")


### PR DESCRIPTION
## Why

The user guide covered how to embed descriptions into images and stopped there. It never said where the description ends up or how to look at it — you run `idt embed`, get a folder of copies, and have no way to confirm anything happened.

## The guide

**User Guide → Embedding Descriptions into Images** gains a field-by-format table and two access sections.

**Windows** — Details view, **Tab** to the column headers, **Shift+F10**, turn on **Comments** or **Title**. Then arrow down the list and each description is announced with its file name. Also covers Alt+Enter → Details for a single file, and searching on the embedded text.

**macOS** — **Cmd+I** for Get Info, Preview's Inspector, Spotlight, `mdls` (with a one-liner for a whole folder), and Photos captions. It also states plainly that Finder's **Comments** column is a Spotlight note kept by Finder and *not* the embedded description, so turning it on shows nothing — that failure mode looks exactly like a failed embed.

Which column to use depends on the format, so the guide says so:

| Format | Comments | Title |
|--------|----------|-------|
| JPEG | ✓ EXIF UserComment | ✓ XMP `dc:description` |
| PNG | ✗ no EXIF | ✓ XMP iTXt chunk |
| WebP | ✓ EXIF UserComment | ✗ no XMP written |
| TIFF | ✓ XPComment | ✓ ImageDescription |

Every row was measured on Windows 11 through the shell property system — the same source Explorer draws its columns from — not inferred.

## The TIFF bug this turned up

Building that table meant embedding into one of each format and looking at the result. The TIFF would not open afterwards.

`embed_image_file()` routed `.tif` and `.tiff` to `_embed_jpeg()`, which walks JPEG marker segments and injects an APP1. Against a TIFF that overwrites the `II*\0` byte-order magic — the file began `II\xff\xe1` — and Pillow, Explorer and Preview all refused it. Nothing raised. The embed reported success and returned a folder of dead files.

- TIFF gets its own writer: `ImageDescription` (270) + `XPComment` (40092) via Pillow.
- Format dispatch moved into one `_embed_by_format()` helper, where an unknown extension is copied and left alone rather than handed to whichever writer looked closest.
- `Embedder._embed_one()` never had a TIFF branch at all, so project-mode embeds silently skipped TIFF metadata. It now shares the dispatcher.

## Tests

Existing coverage (`TestEmbedder`, `TestXmpInjection`) proved copies land in the right directory and carry XMP, but never asserted *which* tag any format got — so neither the corruption nor a silently blank Explorer column could fail CI.

New `pytest_tests/unit/test_embedded_metadata_visibility.py` reads the files back the way each OS does:

- EXIF UserComment via piexif (JPEG, WebP)
- XMP `dc:description` extracted and parsed (JPEG, PNG)
- PNG tEXt and iTXt chunks; TIFF tags 270 and 40092
- Unicode round-trip per format — UserComment is UCS-2, XMP is UTF-8
- Every embedded file still opens; sources never touched; unknown formats byte-identical
- **Windows only:** the actual Explorer column values, asserting the exact instruction the guide gives
- The guide still contains the Windows steps, the macOS steps and the Spotlight Comments caveat

**35 pass. 7 fail against the pre-fix embedder.** Full suite: 1715 passed, 34 skipped.

## Also corrected

`IMAGE_FORMAT_SUPPORT.md` claimed Windows shows no PNG metadata at all (it shows it under Title) and described TIFF as lossless piexif insertion (that was the corrupting path). Left as-is, this PR would have shipped two docs disagreeing about PNG.

## Not verified

- **The macOS steps were not run on a Mac** — none available this session. They rest on XMP `dc:description`, which the new tests confirm is present, plus your own report that Get Info shows it. But nobody ran `mdls` against an embedded file here, and the "More Info section" placement is from your description rather than observation. Worth a confirming pass before anyone leans on the exact wording.
- HEIC was not exercised end to end (it converts to JPEG first, so it inherits a covered path).
- Pandoc is not installed locally, so the new tables and the nested code block were checked for correct indentation but not rendered. Merging to `main` triggers `publish-docs.yml`, which rebuilds the Pages site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
